### PR TITLE
Fix mfa whitelisting

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -80,6 +80,7 @@ UTEST_MODULES = \
 
 FTEST_MODULES = \
 	bitstr \
+	whitelist \
 	otp_int
 
 

--- a/cuter
+++ b/cuter
@@ -20,6 +20,7 @@ function usage() {
     echo "	-fv --fully-verbose		fully verbose execution (for debugging)"
     echo "	-d, --disable-pmatch		disable pmatch compilation"
     echo "	-r, --recompile			recompile the module"
+    echo "	-w, --whitelist			path of the file with the whitelisted MFAs (Each MFA in one line ending with a dot)"
     exit 1
 }
 

--- a/cuter
+++ b/cuter
@@ -82,11 +82,14 @@ if [ $# -ge 3 ]; then
             -v | --verbose)
                 opts=$(add_opt "$opts" "verbose_execution_info")
                 ;;
-            -fv | --fully-verbose)
+           -fv | --fully-verbose)
                 opts=$(add_opt "$opts" "fully_verbose_execution_info")
                 ;;
             -d | --disable-pmatch)
                 opts=$(add_opt "$opts" "disable_pmatch")
+                ;;
+            -w | --whitelist)
+                opts=$(add_opt "$opts" "{whitelist, '$VALUE'}")
                 ;;
             -r | --recompile)
 		## if the .beam file does not exist, it's pointless to

--- a/src/cuter.erl
+++ b/src/cuter.erl
@@ -33,6 +33,7 @@
 -define(DISABLE_PMATCH, disable_pmatch).
 -define(POLLERS_NO, number_of_pollers).
 -define(SOLVERS_NO, number_of_solvers).
+-define(WHITELISTED_MFAS, whitelist).
 
 -type default_option() :: {?POLLERS_NO, ?ONE}
                         .
@@ -44,6 +45,7 @@
                 | ?FULLY_VERBOSE_EXEC_INFO
                 | ?VERBOSE_EXEC_INFO
                 | ?DISABLE_PMATCH
+                | {?WHITELISTED_MFAS, file:filename()}
                 .
 
 %% ----------------------------------------------------------------------------

--- a/test/ftest/expected/whitelist-f-1.expected
+++ b/test/ftest/expected/whitelist-f-1.expected
@@ -1,0 +1,3 @@
+Testing whitelist:f/1 ...
+INPUTS THAT LEAD TO RUNTIME ERRORS
+#1 whitelist:f(424242)

--- a/test/ftest/src/whitelist.erl
+++ b/test/ftest/src/whitelist.erl
@@ -1,0 +1,16 @@
+-module(whitelist).
+-export([f/1, just_loop/1]).
+
+-spec f(pos_integer()) -> pos_integer().
+f(X) ->
+  Z = just_loop(X),
+  case X of
+    424242 -> error(bug);
+    _ -> Z
+  end.
+
+-spec just_loop(pos_integer()) -> ok.
+just_loop(X) when X > 0 ->
+  just_loop(X - 1);
+just_loop(0) ->
+  ok.

--- a/test/ftest/whitelist/whitelist-f-1.txt
+++ b/test/ftest/whitelist/whitelist-f-1.txt
@@ -1,0 +1,1 @@
+{whitelist,just_loop,1}.

--- a/test/functional_test
+++ b/test/functional_test
@@ -13,6 +13,7 @@ tests[6]="bitstr;f31;[<<>>,0];6;-p=2 -s=3;bitstr-f31-2"
 tests[7]="bitstr;f32;[<<>>,0,3];3;-p=2 -s=3;bitstr-f32-3"
 tests[8]="bitstr;f33;[<<>>,0,0,<<>>];5;-p=2 -s=3;bitstr-f33-4"
 tests[9]="otp_int;obsolete;[erlang, length, 1];3;-p=2 -s=3;otp_int-obsolete-3"
+tests[10]="whitelist;f;[42];3;-p=2 -s=3;whitelist-f-1"
 
 for element in "${tests[@]}"; do
   IFS=';' read -a t <<< "$element"

--- a/test/functional_test
+++ b/test/functional_test
@@ -3,26 +3,27 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ebin=$DIR/ftest/ebin
 
-tests[0]="bitstr;f11;[0];2;-p=2 -s=3;bitstr-f11-1"
-tests[1]="bitstr;f12;[0,0,0];6;-p=2 -s=3;bitstr-f12-3"
-tests[2]="bitstr;f13;[0,0,0];15;-p=2 -s=3;bitstr-f13-3"
-tests[3]="bitstr;f21;[<<>>];6;-p=2 -s=3;bitstr-f21-1"
-tests[4]="bitstr;f22;[<<>>,42];8;-p=2 -s=3;bitstr-f22-2"
-tests[5]="bitstr;f23;[0,0];7;-p=2 -s=3;bitstr-f23-2"
-tests[6]="bitstr;f31;[<<>>,0];6;-p=2 -s=3;bitstr-f31-2"
-tests[7]="bitstr;f32;[<<>>,0,3];3;-p=2 -s=3;bitstr-f32-3"
-tests[8]="bitstr;f33;[<<>>,0,0,<<>>];5;-p=2 -s=3;bitstr-f33-4"
-tests[9]="otp_int;obsolete;[erlang, length, 1];3;-p=2 -s=3;otp_int-obsolete-3"
-tests[10]="whitelist;f;[42];3;-p=2 -s=3;whitelist-f-1"
+tests[0]="bitstr;f11;[0];2;-p=2 -s=3;bitstr-f11-1;no-whitelist"
+tests[1]="bitstr;f12;[0,0,0];6;-p=2 -s=3;bitstr-f12-3;no-whitelist"
+tests[2]="bitstr;f13;[0,0,0];15;-p=2 -s=3;bitstr-f13-3;no-whitelist"
+tests[3]="bitstr;f21;[<<>>];6;-p=2 -s=3;bitstr-f21-1;no-whitelist"
+tests[4]="bitstr;f22;[<<>>,42];8;-p=2 -s=3;bitstr-f22-2;no-whitelist"
+tests[5]="bitstr;f23;[0,0];7;-p=2 -s=3;bitstr-f23-2;no-whitelist"
+tests[6]="bitstr;f31;[<<>>,0];6;-p=2 -s=3;bitstr-f31-2;no-whitelist"
+tests[7]="bitstr;f32;[<<>>,0,3];3;-p=2 -s=3;bitstr-f32-3;no-whitelist"
+tests[8]="bitstr;f33;[<<>>,0,0,<<>>];5;-p=2 -s=3;bitstr-f33-4;no-whitelist"
+tests[9]="otp_int;obsolete;[erlang, length, 1];3;-p=2 -s=3;otp_int-obsolete-3;no-whitelist"
+tests[10]="whitelist;f;[1000];3;-p=2 -s=3;whitelist-f-1;whitelist-f-1"
 
 for element in "${tests[@]}"; do
   IFS=';' read -a t <<< "$element"
 
   outfile=$DIR/${t[5]}
   expected=$DIR/ftest/expected/${t[5]}.expected
+  whitelist=$DIR/ftest/whitelist/${t[6]}.txt
 
-  echo -e "\nRunning ./cuter ${t[0]} ${t[1]} '${t[2]}' ${t[3]} ${t[4]} ..."
-  cd "$ebin" && $DIR/../cuter ${t[0]} ${t[1]} "${t[2]}" ${t[3]} ${t[4]} > "$outfile"
+  echo -e "\nRunning ./cuter ${t[0]} ${t[1]} '${t[2]}' ${t[3]} ${t[4]} -w='${t[6]}.txt' ..."
+  cd "$ebin" && $DIR/../cuter ${t[0]} ${t[1]} "${t[2]}" ${t[3]} ${t[4]} -w="$whitelist" > "$outfile"
   if diff -q "$outfile" "$expected"; then
     rm -f "$outfile"
   else

--- a/test/utest/src/cuter_codeserver_tests.erl
+++ b/test/utest/src/cuter_codeserver_tests.erl
@@ -15,7 +15,7 @@ load_modules_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
   Inst = fun(_) ->
-    Cs = cuter_codeserver:start(self(), ?Pmatch),
+    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
     As = [load_mod(Cs, M) || M <- ?MODS_LIST],
     Stop = cuter_codeserver:stop(Cs),
     [{"codeserver termination", ?_assertEqual(ok, Stop)},
@@ -33,7 +33,7 @@ load_and_retrieve_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
   Inst = fun(_) ->
-    Cs = cuter_codeserver:start(self(), ?Pmatch),
+    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
     R1 = cuter_codeserver:load(Cs, lists),
     R2 = cuter_codeserver:load(Cs, os),
     R3 = cuter_codeserver:load(Cs, lists),
@@ -50,7 +50,7 @@ error_load_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
   Inst = fun(_) ->
-    Cs = cuter_codeserver:start(self(), ?Pmatch),
+    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
     R1 = cuter_codeserver:load(Cs, erlang),
     R2 = cuter_codeserver:load(Cs, foobar),
     Stop = cuter_codeserver:stop(Cs),

--- a/test/utest/src/cuter_eval_tests.erl
+++ b/test/utest/src/cuter_eval_tests.erl
@@ -40,7 +40,7 @@ eval_cerl_test_() ->
   [{"Basic Cerl Evaluation: " ++ C, {setup, Setup(I), Cleanup, Inst}} || {C, I} <- Is].
 
 eval_cerl({F, As, Result, Dir}) ->
-  CodeServer = cuter_codeserver:start(self(), ?Pmatch),
+  CodeServer = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
   Server = cuter_iserver:start(?MODULE, F, As, Dir, ?TRACE_DEPTH, CodeServer),
   R = execution_result(Server),
   ok = wait_for_iserver(Server),

--- a/test/utest/src/cuter_iserver_tests.erl
+++ b/test/utest/src/cuter_iserver_tests.erl
@@ -25,7 +25,7 @@ start_stop_test_() ->
 setup() ->
   process_flag(trap_exit, true),
   Dir = cuter_tests_lib:setup_dir(),
-  CodeServer = cuter_codeserver:start(self(), ?Pmatch),
+  CodeServer = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
   Server = cuter_iserver:start(lists, reverse, [[42,17]], Dir, ?TRACE_DEPTH, CodeServer),
   {Dir, Server}.
 


### PR DESCRIPTION
The user can supply a file with exported MFAs that will be whitelisted and will be treated as BIFs.