### PR TITLE
Mfa whitelisting with wildcards

### DIFF
--- a/src/cuter_mock.erl
+++ b/src/cuter_mock.erl
@@ -258,8 +258,15 @@ simulate_behaviour(M, F, A) -> {ok, {M, F, A}}.
 
 %% Checks if an MFA is whitelisted.
 -spec is_whitelisted(mfa(), whitelist()) -> boolean().
-is_whitelisted(MFA, Whitelist) ->
-  sets:is_element(MFA, Whitelist).
+is_whitelisted({M, F, _A}=MFA, Whitelist) ->
+  case sets:is_element(MFA, Whitelist) of
+    true -> true;
+    false ->
+      case sets:is_element({M, F, '*'}, Whitelist) of
+        true -> true;
+        false -> sets:is_element({M, '*', '*'}, Whitelist)
+      end
+  end.
 
 %% Generate the whitelist from the data loaded from the file.
 -spec parse_whitelist(list()) -> whitelist().
@@ -267,10 +274,20 @@ parse_whitelist(LoadedData) -> parse_whitelist(LoadedData, empty_whitelist()).
 
 parse_whitelist([], Acc) ->
   Acc;
-parse_whitelist([{M, F, A}=MFA|Rest], Acc) when is_atom(M), is_atom(F), is_integer(A), A >= 0 ->
-  parse_whitelist(Rest, sets:add_element(MFA, Acc));
-parse_whitelist([_|Rest], Acc) ->
-  parse_whitelist(Rest, Acc).
+parse_whitelist([{M, F, A}=MFA|Rest], Acc) ->
+  case is_mfa(M, F, A) orelse is_any_arity(M, F, A) orelse is_any_fun(M, F, A) of
+    true  -> parse_whitelist(Rest, sets:add_element(MFA, Acc));
+    false -> parse_whitelist(Rest, Acc)
+  end.
+
+is_mfa(M, F, A) when is_atom(M), is_atom(F), is_integer(A), A >= 0 -> true;
+is_mfa(_, _, _) -> false.
+
+is_any_arity(M, F, A) when is_atom(M), is_atom(F), A =:= '*' -> true;
+is_any_arity(_, _, _) -> false.
+
+is_any_fun(M, F, A) when is_atom(M), F =:= '*', A =:= '*' -> true;
+is_any_fun(_, _, _) -> false.
 
 -spec get_whitelisted_mfas(whitelist()) -> [mfa()].
 get_whitelisted_mfas(Whitelist) -> sets:to_list(Whitelist).

--- a/src/cuter_mock.erl
+++ b/src/cuter_mock.erl
@@ -9,7 +9,8 @@
 
 -include("include/cuter_macros.hrl").
 
--type whitelist() :: sets:set(mfa()).
+-type entry() :: {atom(), atom(), byte()} | {atom(), atom(), '*'} | {atom(), '*', '*'}.
+-type whitelist() :: sets:set(entry()).
 
 %% BIFs I found during testing, may be more out there
 %% Returns bif if an MFA is an Erlang BIF
@@ -278,7 +279,9 @@ parse_whitelist([{M, F, A}=MFA|Rest], Acc) ->
   case is_mfa(M, F, A) orelse is_any_arity(M, F, A) orelse is_any_fun(M, F, A) of
     true  -> parse_whitelist(Rest, sets:add_element(MFA, Acc));
     false -> parse_whitelist(Rest, Acc)
-  end.
+  end;
+parse_whitelist([_|Rest], Acc) ->
+  parse_whitelist(Rest, Acc).
 
 is_mfa(M, F, A) when is_atom(M), is_atom(F), is_integer(A), A >= 0 -> true;
 is_mfa(_, _, _) -> false.

--- a/test/ftest/expected/whitelist-g-1.expected
+++ b/test/ftest/expected/whitelist-g-1.expected
@@ -1,0 +1,3 @@
+Testing whitelist:g/1 ...
+INPUTS THAT LEAD TO RUNTIME ERRORS
+#1 whitelist:g(4242)

--- a/test/ftest/src/whitelist.erl
+++ b/test/ftest/src/whitelist.erl
@@ -1,5 +1,5 @@
 -module(whitelist).
--export([f/1, just_loop/1]).
+-export([f/1, g/1, just_loop/1, just_loop2/1]).
 
 -spec f(pos_integer()) -> pos_integer().
 f(X) ->
@@ -9,8 +9,23 @@ f(X) ->
     _ -> Z
   end.
 
--spec just_loop(pos_integer()) -> ok.
+-spec g(pos_integer()) -> pos_integer().
+g(X) ->
+  Z = just_loop2(X),
+  ZZ = lists:seq(1, X),
+  case X of
+    4242 -> error(bug);
+    _ -> Z + lists:sum(ZZ)
+  end.
+
+-spec just_loop(pos_integer()) -> 42.
 just_loop(X) when X > 0 ->
   just_loop(X - 1);
 just_loop(0) ->
-  ok.
+  42.
+
+-spec just_loop2(pos_integer()) -> 42.
+just_loop2(X) when X > 0 ->
+  just_loop(X - 2);
+just_loop2(0) ->
+  42.

--- a/test/ftest/whitelist/whitelist-g-1.txt
+++ b/test/ftest/whitelist/whitelist-g-1.txt
@@ -1,0 +1,2 @@
+{whitelist,just_loop2,'*'}.
+{lists,'*','*'}.

--- a/test/functional_test
+++ b/test/functional_test
@@ -14,6 +14,7 @@ tests[7]="bitstr;f32;[<<>>,0,3];3;-p=2 -s=3;bitstr-f32-3;no-whitelist"
 tests[8]="bitstr;f33;[<<>>,0,0,<<>>];5;-p=2 -s=3;bitstr-f33-4;no-whitelist"
 tests[9]="otp_int;obsolete;[erlang, length, 1];3;-p=2 -s=3;otp_int-obsolete-3;no-whitelist"
 tests[10]="whitelist;f;[1000];3;-p=2 -s=3;whitelist-f-1;whitelist-f-1"
+tests[11]="whitelist;g;[1000];3;-p=2 -s=3;whitelist-g-1;whitelist-g-1"
 
 for element in "${tests[@]}"; do
   IFS=';' read -a t <<< "$element"


### PR DESCRIPTION
The user can whitelist batch of MFAs with

- `{M, F, '*'}`:   `M:F` of any arity.
- `{M, '*', '*'}`:  Any function in module `M`.