### PR TITLE
Do not try to load the abstract code of whitelisted modules

### DIFF
--- a/src/cuter_analyzer.erl
+++ b/src/cuter_analyzer.erl
@@ -190,8 +190,12 @@ calculate_coverage(true, CodeServer, VisitedTags) ->
 
 -spec calculate_coverage(cuter_cerl:visited_tags(), cuter_cerl:visited_tags()) -> {non_neg_integer(), non_neg_integer(), float()}.
 calculate_coverage(Feasible, Visited) ->
-  All = gb_sets:size(Feasible),
-  Diff = gb_sets:subtract(Feasible, Visited),
-  NotVisited = gb_sets:size(Diff),
-  Coverage = 100 * (All - NotVisited) / All,
-  {All - NotVisited, All, Coverage}.
+  case gb_sets:size(Feasible) of
+    0 ->
+      {0, 0, 100.0};
+    All ->
+      Diff = gb_sets:subtract(Feasible, Visited),
+      NotVisited = gb_sets:size(Diff),
+      Coverage = 100 * (All - NotVisited) / All,
+      {All - NotVisited, All, Coverage}
+  end.


### PR DESCRIPTION
The only case that CutEr would try to load the abstract code of
a whitelisted module is when it would try to calculate the callgraph.
This is now fixed as CutEr will ignore such MFAs.