### PR TITLE
Fix issue #16

### DIFF
--- a/src/cuter_json.erl
+++ b/src/cuter_json.erl
@@ -791,7 +791,7 @@ encode_term(Ref, _Seen) when is_bitstring(Ref) ->
 encode_term(Term, _Seen) ->
   throw({unsupported_term, Term}).
 
-encode_maybe_shared_term(T, Seen) when is_integer(T); is_float(T); is_atom(T); 
+encode_maybe_shared_term(T, Seen) when is_integer(T); is_float(T); is_atom(T); is_bitstring(T);
                                        is_list(T); is_tuple(T); is_pid(T); is_reference(T) ->
   case is_shared(T, Seen) of
     false -> encode_term(T, Seen);

--- a/test/utest/src/cuter_json_tests.erl
+++ b/test/utest/src/cuter_json_tests.erl
@@ -52,7 +52,8 @@ encdec_test_() ->
     {"Mixed", [
       {"I", {[1,2],[1,2],{[1,2],[1,2]}}},
       {"II", [1,ok,{4,1},[4,4.5],4,4.5]},
-      {"III", {2.23, true, [2, 3, {234, 34, false}], {ok, fail, 424242}}}
+      {"III", {2.23, true, [2, 3, {234, 34, false}], {ok, fail, 424242}}},
+      {"IV", [<<"true">>]}
     ]}
   ],
   Setup = fun(T) -> fun() -> T end end,
@@ -83,7 +84,8 @@ enc_fail_test_() ->
 encdec_cmd_test_() ->
   Cs = [
     {"I", {1, [self(), erlang:make_ref()]}},
-    {"II", {1, [cuter_symbolic:fresh_symbolic_var(), 42]}}
+    {"II", {1, [cuter_symbolic:fresh_symbolic_var(), 42]}},
+    {"III", {56, [cuter_symbolic:fresh_symbolic_var(), cuter_symbolic:fresh_symbolic_var(), [<<"false">>]]}}
   ],
   Setup = fun(T) -> fun() -> T end end,
   Inst = fun encode_decode_cmd/1,


### PR DESCRIPTION
Fix encoding of terms containing bitstrings and add a unit test.

Previously, terms that have bitstrings as subterms would not be JSON encoded.
In these cases, no log entry was created and the trace file was incomplete; causing runtime errors during solving.

In the case of issue #16, the particular term was 
```erlang
[<<"false">>]
```
and the command that was to be logged was
```
$18 = [ $17 | [<<"false">>] ]
```
where `$17` and `$18` are symbolic variables.