### PR TITLE
Add a Python script to solve constraints in trace files offline

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -93,7 +93,8 @@ FTEST_MODULES = \
 
 PRIV_MODULES = \
 	cuter_io \
-	cuter_z3
+	cuter_z3 \
+	cuter_solve_offline
 
 ###----------------------------------------------------------------------
 ### Targets
@@ -145,7 +146,7 @@ $(FTEST_EBIN)/%.beam: %.erl
 
 utest: $(TARGETS)
 	@(./$(TEST)/eunit_test -e $(EBIN) -u $(UTEST_EBIN) -- $(SRC_MODULES))
-	@(./$(TEST)/python_test -p $(PRIV) -- $(PRIV_MODULES))
+	@(./$(TEST)/python_test -p $(PRIV) -e $(EBIN) -u $(UTEST_EBIN) -- $(PRIV_MODULES))
 
 ftest: $(TARGETS)
 	@(./$(TEST)/functional_test)

--- a/priv/cuter_io.py
+++ b/priv/cuter_io.py
@@ -17,16 +17,16 @@ class JsonReader:
   def __init__(self, filename, end):
     self.fd = gzip.open(filename, 'rb')
     self.cnt = 0
-    self.end = end
-  
+    self.end = int(end)  # TODO Think about loss of precision due to casting.
+
   def read(self, sz):
     return self.fd.read(sz)
-  
+
   # Decode 4 bytes that represent the size of the entry
   def size(self):
     x = [struct.unpack('B', self.read(1))[0] for z in range(4)]
     return (x[0] << 24) | (x[1] << 16) | (x[2] << 8) | x[3]
-  
+
   # Decode 4 bytes that represent the tag of the entry
   def tag(self):
     x = [struct.unpack('B', self.read(1))[0] for z in range(4)]
@@ -39,7 +39,7 @@ class JsonReader:
       raise BinaryEOF
     else:
       return struct.unpack('B', x)[0]
-  
+
   # Decode 1 byte that represents the type of the entry
   def entry_type(self):
     x = self.read(1)
@@ -47,10 +47,10 @@ class JsonReader:
       raise BinaryEOF
     else:
       return struct.unpack('B', x)[0]
-  
+
   def __iter__(self):
     return self
-  
+
   def next(self):
     if self.cnt == self.end:
       raise StopIteration
@@ -65,13 +65,12 @@ class JsonReader:
         self.cnt += 1
         if self.cnt == self.end:
           rev = True
-      
       json_data = json.loads(data)
       clg.json_loaded(self.cnt, k, tp, tag, json_data, rev)
       return tp, tag, json_data, rev
     except BinaryEOF:
       raise StopIteration
-  
+
   def __del__(self):
     self.fd.close()
 

--- a/priv/cuter_solve_offline.py
+++ b/priv/cuter_solve_offline.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+##
+## Solves the constraints in a trace file offline.
+##
+
+import sys, getopt
+import cuter_io as cIO
+import cuter_z3 as cz3
+import cuter_common as cc
+import cuter_print as cpt
+import cuter_global as cglb
+
+def solve(fname, n, printConstraints):
+  # Do the initializations.
+  cglb.init()
+  erlz3 = cz3.ErlangZ3()
+  # Load the trace.
+  r = cIO.JsonReader(fname, n)
+  for tp, tag, x, rev in r:
+    if printConstraints:
+      cpt.print_cmd(tp, tag, x, rev)
+    if cc.is_interpretable(tp):
+      erlz3.command_toZ3(tp, x, rev)
+  # Load the axioms to the solver.
+  erlz3.add_axioms()
+  # Solve the model.
+  print "Solving the model ...",
+  slv = erlz3.solve()
+  print slv
+  if slv == "sat":
+    print erlz3.model
+
+def usage():
+  print "Usage: cuter_solve_offline.py TraceFile NoOfConstraint [ options ]"
+  print "PARAMETERS"
+  print "	TraceFile		The trace file of an execution."
+  print "	NoOfConstraint		The cardinality of the constraint to reverse."
+  print "OPTIONS"
+  print "	--print-constraints	Print all the commands as they are being loaded (for debugging)."
+  print "	--help			Display this information."
+
+if __name__ == "__main__":
+  shortOpts = ""
+  longOpts = ["print-constraints", "help"]
+  try:
+    optlist, remainder = getopt.gnu_getopt(sys.argv[1:], shortOpts, longOpts)
+    printConstraints = False
+    for opt, arg in optlist:
+      if opt == "--help":
+        usage()
+        sys.exit(0)
+      if opt == "--print-constraints":
+        printConstraints = True
+    solve(remainder[0], int(remainder[1]), printConstraints)
+  except Exception as e:
+    print "Fatal Error:", e
+    sys.exit(1)

--- a/priv/cuter_solve_offline.py
+++ b/priv/cuter_solve_offline.py
@@ -5,14 +5,15 @@
 ## Solves the constraints in a trace file offline.
 ##
 
-import sys, getopt
+import sys, getopt, os
+import subprocess as subp
 import cuter_io as cIO
 import cuter_z3 as cz3
 import cuter_common as cc
 import cuter_print as cpt
 import cuter_global as cglb
 
-def solve(fname, n, printConstraints):
+def solve(fname, n, printConstraints, withPrint):
   # Do the initializations.
   cglb.init()
   erlz3 = cz3.ErlangZ3()
@@ -26,11 +27,13 @@ def solve(fname, n, printConstraints):
   # Load the axioms to the solver.
   erlz3.add_axioms()
   # Solve the model.
-  print "Solving the model ...",
+  if withPrint: print "Solving the model ...",
   slv = erlz3.solve()
-  print slv
+  if withPrint: print slv
   if slv == "sat":
-    print erlz3.model
+    m = erlz3.model
+    if withPrint: print m
+    return (slv, str(m))
 
 def usage():
   print "Usage: cuter_solve_offline.py TraceFile NoOfConstraint [ options ]"
@@ -39,21 +42,41 @@ def usage():
   print "	NoOfConstraint		The cardinality of the constraint to reverse."
   print "OPTIONS"
   print "	--print-constraints	Print all the commands as they are being loaded (for debugging)."
+  print "	-e Dir			Dir is the ebin."
+  print "	-u Dir			Dir is the utest ebin."
   print "	--help			Display this information."
 
+def run_tests(ebin, utestEbin):
+  fname = "logfile"
+  cmd = " ".join(["erl", "-noshell", "-pa", ebin, "-pa", utestEbin, "-eval",
+    "\"cuter_tests_lib:sample_trace_file(\\\"{}\\\")\"".format(fname), "-s", "init", "stop"])
+  subp.call(cmd, shell=True)
+  assert ("sat", "[x2 = int(44), x1 = int(1)]") == solve(fname, 3, False, False), "Solver error"
+  try:
+    os.remove(fname)
+  except OSError:
+    pass
+
 if __name__ == "__main__":
-  shortOpts = ""
+  shortOpts = "u:e:"
   longOpts = ["print-constraints", "help"]
   try:
     optlist, remainder = getopt.gnu_getopt(sys.argv[1:], shortOpts, longOpts)
     printConstraints = False
+    ebin, utestEbin = None, None
     for opt, arg in optlist:
       if opt == "--help":
         usage()
         sys.exit(0)
-      if opt == "--print-constraints":
+      elif opt == "--print-constraints":
         printConstraints = True
-    solve(remainder[0], int(remainder[1]), printConstraints)
+      elif opt == "-u":
+        utestEbin = arg
+      elif opt == "-e":
+        ebin = arg
+    if ebin != None or utestEbin != None:
+      sys.exit(run_tests(ebin, utestEbin))
+    solve(remainder[0], int(remainder[1]), printConstraint, True)
   except Exception as e:
     print "Fatal Error:", e
     sys.exit(1)

--- a/test/python_test
+++ b/test/python_test
@@ -5,8 +5,8 @@ import sys, getopt
 import subprocess as subp
 
 def main(argv):
-  shortOpts = "p:h"
-  longOpts = ["path=", "help"]
+  shortOpts = "p:hu:e:"
+  longOpts = ["path=", "help", "utest-ebin=", "ebin="]
   try:
     print "Testing python modules ..."
     optlist, mods = getopt.gnu_getopt(argv, shortOpts, longOpts)
@@ -14,18 +14,30 @@ def main(argv):
       usage()
       sys.exit(1)
     path = None
+    ebin = None
+    utestEbin = None
     # Parse the given options.
     for opt, arg in optlist:
       if opt in ("-p", "--path"):
         path = arg
+      elif opt in ("-u", "--utest-ebin"):
+        utestEbin = arg
+      elif opt in ("-e", "--ebin"):
+        ebin = arg
       elif opt == "--help":
         usage()
         sys.exit(0)
     if path == None:
       print "CutEr's priv directory has not been specified."
       sys.exit(1)
+    if ebin == None:
+      print "CutEr's ebin directory has not been specified."
+    if utestEbin == None:
+      print "CutEr's utest ebin directory has not been specified."
+      sys.exit(1)
     # Run tests.
-    cmds = ["echo \"{} ...\" && python {}/{}.py".format(mod, path, mod) for mod in mods]
+    cmds = ["echo \"{} ...\" && python {}/{}.py -e {} -u {}".format(
+      mod, path, mod, ebin, utestEbin) for mod in mods]
     sys.exit(runCmds(cmds))
   except Exception as e:
     print "Fatal Error:", e
@@ -40,6 +52,7 @@ def usage():
   print "	Mods				A list of space-separated modules."
   print "OPTIONS"
   print "	-p Dir, --path=Dir		The directory Dir of CutEr's priv."
+  print "	-u Dir, --utest-ebin=Dir		The directory Dir of CutEr's priv."
   print "	--help				Display this information."
 
 if __name__ == "__main__":


### PR DESCRIPTION
I have added `cuter_solve_offline.py` in `priv` directory.
It is used to load a trace file and invoke the solver to reverse a specific constraint.

For example
```
aggelgian@lambda:~/git-repos/cuter$ ./priv/cuter_solve_offline.py temp/execexec4/run.trace 3 
Solving the model ... sat
[x1 = atm(acons(116, acons(114, acons(117, acons(101, anil)))))]
```

It also prints the commands in the trace file when the option `--print-constraints` is passed.

This pull request implements feature #18.