### PR TITLE
Add a command line option to append directories to code path

### DIFF
--- a/cuter
+++ b/cuter
@@ -5,9 +5,9 @@ import sys, getopt, os
 import subprocess as subp
 
 def main(argv):
-  shortOpts = "d:p:s:vrw:cl"
+  shortOpts = "d:p:s:vrw:cla:"
   longOpts = [
-    "depth=", "pollers=", "solvers=", "whitelist=",
+    "depth=", "pollers=", "solvers=", "whitelist=", "path-append=",
     "verbose", "fully-verbose", "disable-pmatch", "recompile",
     "coverage", "run-libs", "help", "sorted-errors", "suppress-unsupported"]
   try:
@@ -31,6 +31,7 @@ def main(argv):
     whitelist = None
     recompileModule = False
     runLibs = False
+    appendPath = []
     # Parse the given options.
     runOpts = []
     for opt, arg in optlist:
@@ -42,6 +43,8 @@ def main(argv):
         solvers = int(arg)
       elif opt in ("-w", "--whitelist"):
         whitelist = arg
+      elif opt in ("-a", "--path-append"):
+        appendPath = arg.split(":")
       elif opt in ("-v", "--verbose"):
         runOpts.append("verbose_execution_info")
       elif opt in ("-c", "--coverage"):
@@ -66,9 +69,10 @@ def main(argv):
     runOpts.append("{{number_of_solvers, {}}}".format(solvers))
     if whitelist != None:
       runOpts.append("{{whitelist, '{}'}}".format(whitelist))
+    paths = ["-pa " + directory for directory in appendPath]
 
-    cmd = "erl -noshell -eval \"cuter:run({}, {}, {}, {}, [{}])\" -s init stop".format(
-      module, fun, args, depth, ",".join(runOpts))
+    cmd = "erl -noshell {} -eval \"cuter:run({}, {}, {}, {}, [{}])\" -s init stop".format(
+      " ".join(paths), module, fun, args, depth, ",".join(runOpts))
     if runLibs:
       sys.exit(runCuter(cmd))
     else:
@@ -113,6 +117,8 @@ def usage():
   print "	-s N, --solvers=N		Use N solvers."
   print "	-w File, --whitelist=File	Path of the file with the whitelisted MFAs."
   print "					Write one line ending with a dor for each MFA."
+  print "	-a Dirs, --path-append=Dirs	Appends the Dirs to Erlang's code path."
+  print "					The directories are separated by a colon (:)."
   print "	-v, --verbose			Request a verbose execution."
   print "	-r, --recompile			Recompile the module under test."
   print "	-c, --coverage			Calculate the coverage achieved."

--- a/test/ftest/expected/collection-f1-1.expected
+++ b/test/ftest/expected/collection-f1-1.expected
@@ -1,0 +1,3 @@
+Testing collection:f1/1 ...
+=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+#1 collection:f1(38.86)

--- a/test/ftest/src/collection.erl
+++ b/test/ftest/src/collection.erl
@@ -1,5 +1,5 @@
 -module(collection).
--export([f/1, g/1, g1/1, h/1]).
+-export([f/1, g/1, g1/1, h/1, f1/1]).
 
 -type t() :: [complex_spec:int()].
 
@@ -36,4 +36,11 @@ h(X) ->
     84 -> os:timestamp();
     17 -> error(bug);
     _ -> X
+  end.
+
+-spec f1(number()) -> ok.
+f1(X) ->
+  case types_and_specs:f11(X) of
+    42.0 -> error(bug);
+    _ -> ok
   end.

--- a/test/functional_test
+++ b/test/functional_test
@@ -2,6 +2,7 @@
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ebin=$DIR/ftest/ebin
+utest_ebin=$DIR/utest/ebin
 
 tests[0]="bitstr;f11;[0];9;-p 2 -s 3;bitstr-f11-1;no-whitelist"
 tests[1]="bitstr;f12;[0,0,0];14;-p 2 -s 3;bitstr-f12-3;no-whitelist"
@@ -29,6 +30,7 @@ tests[22]="collection;f;[[]];10;-p 4 -s 4;collection-f-1;no-whitelist"
 tests[23]="collection;g;[1];2;-p 4 -s 4;collection-g-1;no-whitelist"
 tests[24]="collection;g1;[1];2;-p 4 -s 4;collection-g1-1;no-whitelist"
 tests[25]="collection;h;[1];2;-p 4 -s 4;collection-h-1;no-whitelist"
+tests[26]="collection;f1;[1];4;-p 4 -s 4 -a ${utest_ebin};collection-f1-1;no-whitelist"
 
 for element in "${tests[@]}"; do
   IFS=';' read -a t <<< "$element"


### PR DESCRIPTION
The user can append Dir1, Dir2, etc to the code path when invoking
the cuter script by running
```
cuter Mod Fun '[Arg1, Arg2, ..., ArgN]' -a Dir1:Dir2:..:DirN
```
or
```
cuter Mod Fun '[Arg1, Arg2, ..., ArgN]' --append-path=Dir1:Dir2:..:DirN
```

This pull request implements the feature #14.