### PR TITLE
Replace getopt module with argparse

### DIFF
--- a/cuter
+++ b/cuter
@@ -1,137 +1,120 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys, getopt, os
+import sys, argparse, os
 import subprocess as subp
 
-def main(argv):
-  shortOpts = "d:p:s:vrw:cla:"
-  longOpts = [
-    "depth=", "pollers=", "solvers=", "whitelist=", "path-append=",
-    "verbose", "fully-verbose", "disable-pmatch", "recompile",
-    "coverage", "run-libs", "help", "sorted-errors", "suppress-unsupported"]
-  try:
-    optlist, remainder = getopt.gnu_getopt(argv, shortOpts, longOpts)
-    # Ensure that there are enough arguments.
-    if len(remainder) < 3:
-      usage()
+def main():
+  parser = argparse.ArgumentParser(description="Run the CutEr tool.")
+  # Add positional arguments.
+  parser.add_argument("module", metavar="M", help="the module")
+  parser.add_argument("fun", metavar="F", help="the function")
+  parser.add_argument("args", metavar="'[A1,...,An]'", help="the arguments of the MFA given as a list")
+  # Add optional arguments
+  parser.add_argument("-pa", nargs='+', default=[], metavar="Dir", help="preppends each Dir to Erlang's code path")
+  parser.add_argument("-pz", nargs='+', default=[], metavar="Dir", help="appends each Dir to Erlang's code path")
+  parser.add_argument("-d", "--depth", metavar="D", type=int, default=25, help="the depth limit D of the search")
+  parser.add_argument("-p", "--pollers", metavar="N", type=int, default=1,
+    help="use N pollers (default: %(default)s)")
+  parser.add_argument("-s", "--solvers", metavar="N", type=int, default=1,
+    help="use N solvers (default: %(default)s)")
+  parser.add_argument("-w", metavar="P",
+    help="the path P of the file with the whitelisted MFAs. Write one line for each MFA, ending with a dot")
+  parser.add_argument("-v", "--verbose", action='store_true', help="request a verbose execution")
+  parser.add_argument("-r", "--recompile", action='store_true', help="recompile the module under test")
+  parser.add_argument("-c", "--coverage", action='store_true', help="calculate the coverage achieved")
+  parser.add_argument("--fully-verbose", action='store_true', help="request a fully verbose execution (for debugging)")
+  parser.add_argument("--disable-pmatch", action='store_true', help="disable the pattern matching compilation")
+  parser.add_argument("--sorted-errors", action='store_true', help="report the erroneous inputs in a sorted order")
+  parser.add_argument("--suppress-unsupported", action='store_true', help="suppresses the reporting of unsupported MFAs")
+
+  # Parse the arguments
+  args = parser.parse_args()
+
+  # First, recompile the module, if requested.
+  if args.recompile:
+    if compileModule(args.module, True) == 1:
       sys.exit(1)
-    # Export ERL_LIBS.
-    erl_libs = os.getenv("ERL_LIBS")
-    if erl_libs != None:
-      os.environ["ERL_LIBS"] = getDirectory() + ":" + erl_libs
-    else:
-      os.environ["ERL_LIBS"] = getDirectory()
-    # Read the arguments.
-    module, fun, args = remainder[0], remainder[1], remainder[2]
-    # Set the default options.
-    depth = 25
-    pollers = 1
-    solvers = 1
-    whitelist = None
-    recompileModule = False
-    runLibs = False
-    appendPath = []
-    # Parse the given options.
-    runOpts = []
-    for opt, arg in optlist:
-      if opt == "-d":
-        depth = int(arg)
-      elif opt in ("-p", "--pollers"):
-        pollers = int(arg)
-      elif opt in ("-s", "--solvers"):
-        solvers = int(arg)
-      elif opt in ("-w", "--whitelist"):
-        whitelist = arg
-      elif opt in ("-a", "--path-append"):
-        appendPath = arg.split(":")
-      elif opt in ("-v", "--verbose"):
-        runOpts.append("verbose_execution_info")
-      elif opt in ("-c", "--coverage"):
-        runOpts.append("coverage")
-      elif opt in ("-r", "--recompile"):
-        recompileModule = True
-      elif opt in ("-l", "--run-libs"):
-        runLibs = True
-      elif opt == "--fully-verbose":
-        runOpts.append("fully_verbose_execution_info")
-      elif opt == "--disable-pmatch":
-        runOpts.append("disable_pmatch")
-      elif opt == "--sorted-errors":
-        runOpts.append("sorted_errors")
-      elif opt == "--suppress-unsupported":
-        runOpts.append("suppress_unsupported")
-      elif opt == "--help":
-        usage()
-        sys.exit(0)
 
-    runOpts.append("{{number_of_pollers, {}}}".format(pollers))
-    runOpts.append("{{number_of_solvers, {}}}".format(solvers))
-    if whitelist != None:
-      runOpts.append("{{whitelist, '{}'}}".format(whitelist))
-    paths = ["-pa " + directory for directory in appendPath]
+  # The directories that will be appended to the code path.
+  paths = "".join([
+    "-pa " + " ".join(args.pa) if len(args.pa) > 0 else "",
+    "-pz " + " ".join(args.pz) if len(args.pz) > 0 else ""
+  ])
 
-    cmd = "erl -noshell {} -eval \"cuter:run({}, {}, {}, {}, [{}])\" -s init stop".format(
-      " ".join(paths), module, fun, args, depth, ",".join(runOpts))
-    if runLibs:
-      sys.exit(runCuter(cmd))
-    else:
-      compiledStatus, log = compileModule(module, recompileModule)
-      if compiledStatus == 0:
-        sys.exit(runCuter(cmd))
-      else:
-        print log
-        sys.exit(1)
-  except Exception as e:
-    print "Fatal Error:", e
+  # Export ERL_LIBS.
+  erl_libs = os.getenv("ERL_LIBS")
+  if erl_libs != None:
+    os.environ["ERL_LIBS"] = getDirectory() + ":" + erl_libs
+  else:
+    os.environ["ERL_LIBS"] = getDirectory()
+
+  # Check if the module exists in the code path.
+  cmd = "erl -noshell {} -eval \"erlang:display(code:which({})),halt()\"".format(paths, args.module)
+  p = subp.Popen(cmd, shell=True, stdin=subp.PIPE, stdout=subp.PIPE, stderr=subp.STDOUT, close_fds=True)
+  out, err = p.communicate()
+  if err:
+    print "Error in searching for {}: {} ...".format(args.module, err)
     sys.exit(1)
+  out = out.strip().strip("\"")
+
+  # If the module is non_existing try to compile it.
+  if out == "non_existing":
+    if compileModule(args.module) == 1:
+      sys.exit(1)
+  elif len(out) < 4 or out[-4:] != "beam":
+    print "Module {} is {} ...".format(args.module, out)
+    sys.exit(1)
+
+  # We only get here if the module is either compiled, or found in the code path.
+  # Now set CutEr's runtime options.
+  opts = []
+  opts.append("{{number_of_pollers, {}}}".format(args.pollers))
+  opts.append("{{number_of_solvers, {}}}".format(args.solvers))
+  if args.verbose:
+    opts.append("verbose_execution_info")
+  if args.coverage:
+    opts.append("coverage")
+  if args.fully_verbose:
+    opts.append("fully_verbose_execution_info")
+  if args.disable_pmatch:
+    opts.append("disable_pmatch")
+  if args.sorted_errors:
+    opts.append("sorted_errors")
+  if args.suppress_unsupported:
+    opts.append("suppress_unsupported")
+  if args.w != None:
+      opts.append("{{whitelist, '{}'}}".format(args.w))
+  strOpts = ",".join(opts)
+
+  # Run CutEr
+  cmd = "erl -noshell {} -eval \"cuter:run({}, {}, {}, {}, [{}])\" -s init stop".format(
+    paths, args.module, args.fun, args.args, args.depth, strOpts)
+  sys.exit(subp.call(cmd, shell=True))
 
 def getDirectory():
   return os.path.dirname(os.path.realpath(__file__))
 
 def compileModule(module, again = False):
+  """
+  Tries to compile the module.
+  It expects that the erl file is located in the current working directory.
+  """
   exists = os.path.isfile(module + ".beam")
   if again or not exists:
     erl = module + ".erl"
     if not os.path.isfile(erl):
-      return 1, "Cannot locate {} ...  ".format(erl)
+      print "Cannot locate {} ...  ".format(erl)
+      return 1
     print "Compiling {} ...".format(erl),
     p = subp.Popen(["erlc", "+debug_info", erl], stdout=subp.PIPE, stderr=subp.PIPE)
     out, err = p.communicate()
     print "OK" if p.returncode == 0 else "ERROR"
     return p.returncode, "\n".join([out.strip(), err.strip()]).strip()
-  return 0, ""
-
-def runCuter(cmd):
-  return subp.call(cmd, shell=True)
-
-def usage():
-  print "Usage: cuter M F '[A1,...,An]' [ options ]"
-  print "PARAMETERS"
-  print "	M				The module."
-  print "	F				The function."
-  print "	'[A1,...,An]'			The arguments of the MFA given as a list."
-  print "OPTIONS"
-  print "	-d D, --depth=D			The depth limit D of the search."
-  print "	-p N, --pollers=N		Use N pollers."
-  print "	-s N, --solvers=N		Use N solvers."
-  print "	-w File, --whitelist=File	Path of the file with the whitelisted MFAs."
-  print "					Write one line ending with a dor for each MFA."
-  print "	-a Dirs, --path-append=Dirs	Appends the Dirs to Erlang's code path."
-  print "					The directories are separated by a colon (:)."
-  print "	-v, --verbose			Request a verbose execution."
-  print "	-r, --recompile			Recompile the module under test."
-  print "	-c, --coverage			Calculate the coverage achieved."
-  print "	-l, --run-libs			The tested MFA is already loaded, so do not look"
-  print "					for the .erl file in the current directory."
-  print "	--fully-verbose			Request a fully verbose execution (for debugging)."
-  print "	--disable-pmatch		Disable the pattern matching compilation."
-  print "	--sorted-errors			Report the erroneous inputs in a sorted order."
-  print "	--suppress-unsupported		Suppresses the reporting of unsupported MFAs."
-  print "	--help				Display this information."
+  return 0
 
 if __name__ == "__main__":
   try:
-    main(sys.argv[1:])
+    main()
   except KeyboardInterrupt:
     sys.exit(1)

--- a/test/functional_test
+++ b/test/functional_test
@@ -30,7 +30,7 @@ tests[22]="collection;f;[[]];10;-p 4 -s 4;collection-f-1;no-whitelist"
 tests[23]="collection;g;[1];2;-p 4 -s 4;collection-g-1;no-whitelist"
 tests[24]="collection;g1;[1];2;-p 4 -s 4;collection-g1-1;no-whitelist"
 tests[25]="collection;h;[1];2;-p 4 -s 4;collection-h-1;no-whitelist"
-tests[26]="collection;f1;[1];4;-p 4 -s 4 -a ${utest_ebin};collection-f1-1;no-whitelist"
+tests[26]="collection;f1;[1];4;-p 4 -s 4 -pa ${utest_ebin};collection-f1-1;no-whitelist"
 
 for element in "${tests[@]}"; do
   IFS=';' read -a t <<< "$element"


### PR DESCRIPTION
Also remove the -l option.
CutEr now first tries to find the module in the code path.
This check is bypassed with the -r option.
If the module is non existent, then it tries to compile it.

This pull request closes issues #24 and #31.