### PR TITLE
Fix issue #26

### DIFF
--- a/include/cuter_macros.hrl
+++ b/include/cuter_macros.hrl
@@ -219,6 +219,3 @@
 
 %% All the MFAs that are supported for symbolic evaluation.
 -define(SUPPORTED_MFAS, gb_sets:from_list(dict:fetch_keys(?OPCODE_MAPPING))).
-
--define(UNSUPPORTED_MFAS,
-  gb_sets:from_list([ {cuter_erlang, unsupported_lt, 2} ])).

--- a/src/cuter_erlang.erl
+++ b/src/cuter_erlang.erl
@@ -615,7 +615,21 @@ lt_list([X|Xs], [Y|Ys]) ->
     false -> ?MODULE:'<'(X, Y)
   end.
 
--type t() :: atom() | bitstring() | function() | map() | maybe_improper_list()
+-spec lt_bitstring(bitstring(), bitstring()) -> boolean().
+lt_bitstring(<<>>, <<>>) ->
+  false;
+lt_bitstring(<<>>, _) ->
+  true;
+lt_bitstring(_, <<>>) ->
+  false;
+lt_bitstring(<<1:1, _/bitstring>>, <<0:1, _/bitstring>>) ->
+  false;
+lt_bitstring(<<0:1, _/bitstring>>, <<1:1, _/bitstring>>) ->
+  true;
+lt_bitstring(<<_:1, Xs/bitstring>>, <<_:1, Ys/bitstring>>) ->
+  lt_bitstring(Xs, Ys).
+
+-type t() :: atom() | function() | map() | maybe_improper_list()
            | number() | pid() | port() | reference()| tuple().
 -spec '<'(t(), any()) -> boolean().
 %% Left operand is a number.
@@ -681,10 +695,14 @@ lt_list([X|Xs], [Y|Ys]) ->
   false;
 '<'(X, _Y) when is_list(X) ->
   true;
-%% Left operand is a reference, a function, a port, a pid, a map or a bistring.
+'<'(X, Y) when is_bitstring(X), is_bitstring(Y) ->
+  lt_bitstring(X, Y);
+'<'(X, _Y) when is_bitstring(X) ->
+  false;
+%% Left operand is a reference, a function, a port, a pid, or a map.
 %% These terms are 'incomprehensible' for the solver, thus we directly call
 %% the erlang:'<'/2 operator.
-%'<'(X, Y) when is_reference(X); is_function(X); is_port(X); is_pid(X); is_map(X); is_bitstring(X) ->
+%'<'(X, Y) when is_reference(X); is_function(X); is_port(X); is_pid(X); is_map(X) ->
 '<'(X, Y) ->
   unsupported_lt(X, Y).
 

--- a/src/cuter_mock.erl
+++ b/src/cuter_mock.erl
@@ -4,7 +4,7 @@
 
 -export([simulate_behaviour/3, is_whitelisted/2, parse_whitelist/1,
          get_whitelisted_mfas/1, empty_whitelist/0, overriding_modules/0,
-         no_symbolic_evalution/1]).
+         no_symbolic_evalution/1, is_internal_without_symbolic_representation/1]).
 
 -export_type([whitelist/0]).
 
@@ -62,7 +62,7 @@ simulate_behaviour(erlang, _F, _A)        -> bif;
 %% cuter_erlang module
 simulate_behaviour(cuter_erlang, F, A) ->
   MFA = {cuter_erlang, F, A},
-  case gb_sets:is_member(MFA, ?SUPPORTED_MFAS) orelse gb_sets:is_member(MFA, ?UNSUPPORTED_MFAS) of
+  case gb_sets:is_member(MFA, ?SUPPORTED_MFAS) orelse is_internal_without_symbolic_representation(MFA) of
     true  -> bif;
     false -> {ok, MFA}
   end;
@@ -259,6 +259,19 @@ simulate_behaviour(M, F, A) ->
     true  -> bif;
     false -> {ok, Mfa}
   end.
+
+%% ----------------------------------------------------------------------------
+%% Internal MFAs without symbolic interpretation.
+%% ----------------------------------------------------------------------------
+
+%% Creates a set of MFAs that are defined in cuter_erlang in overriding some
+%% Erlang BIFs but have no symbolic interpretation (yet).
+internal_mfas_without_symbolic_representation() ->
+  gb_sets:from_list([ {cuter_erlang, unsupported_lt, 2} ]).
+
+-spec is_internal_without_symbolic_representation(mfa()) -> boolean().
+is_internal_without_symbolic_representation(MFA) ->
+  gb_sets:is_member(MFA, internal_mfas_without_symbolic_representation()).
 
 %% ----------------------------------------------------------------------------
 %% MFAs that have no meaning in being evaluated symbolically.

--- a/src/cuter_pp.erl
+++ b/src/cuter_pp.erl
@@ -812,9 +812,18 @@ pp_unsupported_mfas(Logs, Whitelist, false) ->
   case filter_non_reportable(UnsupportedMfas, Whitelist) of
     [] -> ok;
     Mfas ->
-      io:format("~n=== UNSUPPORTED MFAS ===~n"),
-      lists:foreach(fun pp_mfa/1, Mfas)
+      {Internal, External} =
+        lists:partition(fun cuter_mock:is_internal_without_symbolic_representation/1, Mfas),
+      io:format("~n=== BIFs Currently without Symbolic Interpretation ===~n"),
+      lists:foreach(fun pp_mfa/1, External),
+      pp_internal_unsupported(Internal)
   end.
+
+pp_internal_unsupported([]) ->
+  ok;
+pp_internal_unsupported(Mfas) ->
+  io:format("~n=== Internal BIFs Where Precision Was Lost ===~n"),
+  lists:foreach(fun pp_mfa/1, Mfas).
 
 pp_mfa({M, F, A}) ->
   io:format("~p:~p/~w~n", [M, F, A]).
@@ -875,10 +884,10 @@ pp_path_vertex_fully_verbose(Vertex) ->
 -spec pp_erroneous_inputs(cuter:erroneous_inputs(), mfa(), level()) -> ok.
 pp_erroneous_inputs([], _MFA, Level) ->
   pp_nl(true, Level =:= ?MINIMAL),
-  io:format("NO RUNTIME ERRORS OCCURED~n");
+  io:format("No Runtime Errors Occured~n");
 pp_erroneous_inputs(Errors, MFA, Level) ->
   pp_nl(true, Level =:= ?MINIMAL),
-  io:format("=== INPUTS THAT LEAD TO RUNTIME ERRORS ==="),
+  io:format("=== Inputs That Lead to Runtime Errors ==="),
   pp_erroneous_inputs_h(Errors, MFA, 1).
 
 pp_erroneous_inputs_h([], _MFA, _N) ->

--- a/test/ftest/expected/bitstr-f11-1.expected
+++ b/test/ftest/expected/bitstr-f11-1.expected
@@ -1,3 +1,3 @@
 Testing bitstr:f11/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f11(42)

--- a/test/ftest/expected/bitstr-f12-3.expected
+++ b/test/ftest/expected/bitstr-f12-3.expected
@@ -1,3 +1,3 @@
 Testing bitstr:f12/3 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f12(0, 5, 2)

--- a/test/ftest/expected/bitstr-f13-3.expected
+++ b/test/ftest/expected/bitstr-f13-3.expected
@@ -1,5 +1,5 @@
 Testing bitstr:f13/3 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f13(3, 2, 3)
 #2 bitstr:f13(6, 3, 2)
 #3 bitstr:f13(26, 5, 0)

--- a/test/ftest/expected/bitstr-f21-1.expected
+++ b/test/ftest/expected/bitstr-f21-1.expected
@@ -1,3 +1,3 @@
 Testing bitstr:f21/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f21(<<0,42:7>>)

--- a/test/ftest/expected/bitstr-f22-2.expected
+++ b/test/ftest/expected/bitstr-f22-2.expected
@@ -1,3 +1,3 @@
 Testing bitstr:f22/2 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f22(<<42:6>>, 6)

--- a/test/ftest/expected/bitstr-f23-2.expected
+++ b/test/ftest/expected/bitstr-f23-2.expected
@@ -1,3 +1,3 @@
 Testing bitstr:f23/2 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f23(9, 5)

--- a/test/ftest/expected/bitstr-f24-2.expected
+++ b/test/ftest/expected/bitstr-f24-2.expected
@@ -1,4 +1,4 @@
 Testing bitstr:f24/2 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f24(<<42:6>>, 6)
 #2 bitstr:f24(<<42:6>>, 6)

--- a/test/ftest/expected/bitstr-f25-2.expected
+++ b/test/ftest/expected/bitstr-f25-2.expected
@@ -1,3 +1,3 @@
 Testing bitstr:f25/2 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f25(<<42:6>>, 6)

--- a/test/ftest/expected/bitstr-f26-2.expected
+++ b/test/ftest/expected/bitstr-f26-2.expected
@@ -1,4 +1,4 @@
 Testing bitstr:f26/2 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f26(<<"*">>, 8)
 #2 bitstr:f26(<<42:6>>, 6)

--- a/test/ftest/expected/bitstr-f27-2.expected
+++ b/test/ftest/expected/bitstr-f27-2.expected
@@ -1,2 +1,2 @@
 Testing bitstr:f27/2 ...
-NO RUNTIME ERRORS OCCURED
+No Runtime Errors Occured

--- a/test/ftest/expected/bitstr-f31-2.expected
+++ b/test/ftest/expected/bitstr-f31-2.expected
@@ -1,3 +1,3 @@
 Testing bitstr:f31/2 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f31(<<0:4>>, 0)

--- a/test/ftest/expected/bitstr-f32-3.expected
+++ b/test/ftest/expected/bitstr-f32-3.expected
@@ -1,3 +1,3 @@
 Testing bitstr:f32/3 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f32(<<64,3:3>>, 0, 0)

--- a/test/ftest/expected/bitstr-f33-4.expected
+++ b/test/ftest/expected/bitstr-f33-4.expected
@@ -1,4 +1,4 @@
 Testing bitstr:f33/4 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f33(<<0:1>>, 0, 0, <<0:1>>)
 #2 bitstr:f33(<<0:1>>, 0, 0, <<0:1>>)

--- a/test/ftest/expected/bitstr-f34-2.expected
+++ b/test/ftest/expected/bitstr-f34-2.expected
@@ -1,2 +1,2 @@
 Testing bitstr:f34/2 ...
-NO RUNTIME ERRORS OCCURED
+No Runtime Errors Occured

--- a/test/ftest/expected/bitstr-f35-1.expected
+++ b/test/ftest/expected/bitstr-f35-1.expected
@@ -1,2 +1,2 @@
 Testing bitstr:f35/1 ...
-NO RUNTIME ERRORS OCCURED
+No Runtime Errors Occured

--- a/test/ftest/expected/bitstr-f36-1.expected
+++ b/test/ftest/expected/bitstr-f36-1.expected
@@ -1,2 +1,2 @@
 Testing bitstr:f36/1 ...
-NO RUNTIME ERRORS OCCURED
+No Runtime Errors Occured

--- a/test/ftest/expected/bitstr-f37-1.expected
+++ b/test/ftest/expected/bitstr-f37-1.expected
@@ -1,3 +1,3 @@
 Testing bitstr:f37/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 bitstr:f37(<<0,0,0,0,0,0:2>>)

--- a/test/ftest/expected/collection-f-1.expected
+++ b/test/ftest/expected/collection-f-1.expected
@@ -1,3 +1,3 @@
 Testing collection:f/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 collection:f([17,17,42])

--- a/test/ftest/expected/collection-f1-1.expected
+++ b/test/ftest/expected/collection-f1-1.expected
@@ -1,3 +1,3 @@
 Testing collection:f1/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 collection:f1(38.86)

--- a/test/ftest/expected/collection-g-1.expected
+++ b/test/ftest/expected/collection-g-1.expected
@@ -1,5 +1,5 @@
 Testing collection:g/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 collection:g(42)
 #2 collection:g([0])
 #3 collection:g("*")

--- a/test/ftest/expected/collection-g1-1.expected
+++ b/test/ftest/expected/collection-g1-1.expected
@@ -1,5 +1,5 @@
 Testing collection:g1/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 collection:g1(1)
 #2 collection:g1(42)
 #3 collection:g1([0])

--- a/test/ftest/expected/collection-h-1.expected
+++ b/test/ftest/expected/collection-h-1.expected
@@ -1,6 +1,6 @@
 Testing collection:h/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 collection:h(17)
 
-=== UNSUPPORTED MFAS ===
+=== BIFs Currently without Symbolic Interpretation ===
 erlang:get/1

--- a/test/ftest/expected/complex_spec-f-1.expected
+++ b/test/ftest/expected/complex_spec-f-1.expected
@@ -1,3 +1,3 @@
 Testing complex_spec:f/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 complex_spec:f([{[1,2],[{[[1],[2]],[3.14]},2]}])

--- a/test/ftest/expected/funs-f1-1.expected
+++ b/test/ftest/expected/funs-f1-1.expected
@@ -1,4 +1,4 @@
 Testing funs:f1/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f1(0)
 #2 funs:f1(fun(3) -> 42; (10) -> 17; (_) -> 42 end)

--- a/test/ftest/expected/funs-f2-3.expected
+++ b/test/ftest/expected/funs-f2-3.expected
@@ -1,4 +1,4 @@
 Testing funs:f2/3 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f2(2, 0, 1)
 #2 funs:f2(fun(0) -> 42; (2) -> 17; (_) -> 42 end, 0, 2)

--- a/test/ftest/expected/funs-f3-3.expected
+++ b/test/ftest/expected/funs-f3-3.expected
@@ -1,4 +1,4 @@
 Testing funs:f3/3 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f3(2, 0, 1)
 #2 funs:f3(fun(5) -> 17; (0) -> 4; (4) -> 42; (2) -> 5; (_) -> 17 end, 0, 2)

--- a/test/ftest/expected/funs-f41-3.expected
+++ b/test/ftest/expected/funs-f41-3.expected
@@ -1,5 +1,5 @@
 Testing funs:f41/3 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f41(2, 0, 1)
 #2 funs:f41(fun(0) -> 4; (_) -> 4 end, 0, 2)
 #3 funs:f41(fun(0) -> fun(2) -> 42; (_) -> 42 end; (_) -> fun(2) -> 42; (_) -> 42 end end, 0, 2)

--- a/test/ftest/expected/funs-f42-3.expected
+++ b/test/ftest/expected/funs-f42-3.expected
@@ -1,5 +1,5 @@
 Testing funs:f42/3 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f42(fun(0) -> 4; (_) -> 4 end, 0, 2)
 #2 funs:f42(fun(0) -> {4, 5}; (_) -> {4, 5} end, 0, 2)
 #3 funs:f42(fun(0) -> fun(2) -> 42; (_) -> 42 end; (_) -> fun(2) -> 42; (_) -> 42 end end, 0, 2)

--- a/test/ftest/expected/funs-f5-4.expected
+++ b/test/ftest/expected/funs-f5-4.expected
@@ -1,4 +1,4 @@
 Testing funs:f5/4 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f5(3, 0, 1, 2)
 #2 funs:f5(fun(2,1,0) -> 17; (0,1,2) -> 42; (_,_,_) -> 17 end, 0, 1, 2)

--- a/test/ftest/expected/funs-f6-1.expected
+++ b/test/ftest/expected/funs-f6-1.expected
@@ -1,4 +1,4 @@
 Testing funs:f6/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f6(42)
 #2 funs:f6(fun(42) -> 42; (_) -> 42 end)

--- a/test/ftest/expected/funs-f7-2.expected
+++ b/test/ftest/expected/funs-f7-2.expected
@@ -1,5 +1,5 @@
 Testing funs:f7/2 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f7(3, [])
 #2 funs:f7(fun(1,0) -> 5; (3,5) -> 42; (_,_) -> 5 end, [1,3])
 #3 funs:f7(fun(1,0) -> 42; (_,_) -> 42 end, [1])

--- a/test/ftest/expected/funs-f8-2.expected
+++ b/test/ftest/expected/funs-f8-2.expected
@@ -1,5 +1,5 @@
 Testing funs:f8/2 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f8(3, [])
 #2 funs:f8(fun(_) -> 0 end, [])
 #3 funs:f8(fun(2) -> 3; (_) -> 3 end, [2])

--- a/test/ftest/expected/funs-f91-3.expected
+++ b/test/ftest/expected/funs-f91-3.expected
@@ -1,5 +1,5 @@
 Testing funs:f91/3 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f91(1, 1, 1)
 #2 funs:f91(1, 1, 2)
 #3 funs:f91(fun(2) -> 42; (_) -> 42 end, 2, 1)

--- a/test/ftest/expected/funs-f92-2.expected
+++ b/test/ftest/expected/funs-f92-2.expected
@@ -1,5 +1,5 @@
 Testing funs:f92/2 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 funs:f92(1, 1)
 #2 funs:f92(fun(2) -> 42; (_) -> 42 end, 2)
 #3 funs:f92(fun(1,1) -> 42; (_,_) -> 42 end, 1)

--- a/test/ftest/expected/otp_int-obsolete-3.expected
+++ b/test/ftest/expected/otp_int-obsolete-3.expected
@@ -1,3 +1,3 @@
 Testing otp_int:obsolete/3 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 otp_int:obsolete(ssl, negotiated_next_protocol, 1)

--- a/test/ftest/expected/whitelist-f-1.expected
+++ b/test/ftest/expected/whitelist-f-1.expected
@@ -1,3 +1,3 @@
 Testing whitelist:f/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 whitelist:f(424242)

--- a/test/ftest/expected/whitelist-g-1.expected
+++ b/test/ftest/expected/whitelist-g-1.expected
@@ -1,3 +1,3 @@
 Testing whitelist:g/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 whitelist:g(4242)

--- a/test/ftest/expected/whitelist-k-1.expected
+++ b/test/ftest/expected/whitelist-k-1.expected
@@ -1,3 +1,3 @@
 Testing whitelist:k/1 ...
-=== INPUTS THAT LEAD TO RUNTIME ERRORS ===
+=== Inputs That Lead to Runtime Errors ===
 #1 whitelist:k(42)

--- a/test/utest/src/cuter_erlang_tests.erl
+++ b/test/utest/src/cuter_erlang_tests.erl
@@ -12,6 +12,7 @@
 props_test_() ->
   Props = [
     {"erlang:'<'/2 => cuter_erlang:'<'/2", prop_lt(), 2000}
+  , {"erlang:'<'/2 (bitstring) => cuter_erlang:'<'/2", prop_lt_bitstring(), 2000}
   , {"erlang:'=<'/2 => cuter_erlang:'=<'/2", prop_lteq(), 2000}
   , {"erlang:'>'/2 => cuter_erlang:'>'/2", prop_gt(), 2000}
   , {"erlang:'>='/2 => cuter_erlang:'>='/2", prop_gteq(), 2000}
@@ -27,6 +28,10 @@ props_test_() ->
 -spec prop_lt() -> proper:outer_test().
 prop_lt() ->
   ?FORALL({X,Y}, {any(),any()}, (X < Y) =:= cuter_erlang:'<'(X, Y)).
+
+-spec prop_lt_bitstring() -> proper:outer_test().
+prop_lt_bitstring() ->
+  ?FORALL({X,Y}, {bitstring(),bitstring()}, (X < Y) =:= cuter_erlang:'<'(X, Y)).
 
 -spec prop_lteq() -> proper:outer_test().
 prop_lteq() ->


### PR DESCRIPTION
- Amend `cuter_erlang:'<'/2` function to include bitstrings. Added the `lt_bitstring/2` MFA in that module.
- Print the internal unsupported MFAs in a separate section.

This pull request fixes issue #26.