### PR TITLE
Support bit_size/1 & byte_size/1

### DIFF
--- a/src/cuter_erlang.erl
+++ b/src/cuter_erlang.erl
@@ -27,7 +27,7 @@
         , '+'/2, '-'/2, '*'/2, '/'/2
         , hd/1, tl/1
         , '++'/2, '--'/2, reverse/2, member/2, keyfind/3
-        , is_binary/1
+        , is_binary/1, bit_size/1, byte_size/1
         ]).
 
 %% XXX When adding type constraints for spec, the overriding funs must be ignored
@@ -911,4 +911,31 @@ is_binary(<<_:1, Bin/bitstring>>, N) ->
   case N of
     7 -> is_binary(Bin, 0);
     _ -> is_binary(Bin, N+1)
+  end.
+
+%%
+%% Simulate erlang:bit_size/1
+%%
+%% Calculates the size of a bitstring in bits.
+-spec bit_size(bitstring()) -> non_neg_integer().
+bit_size(Bin) -> bit_size(Bin, 0).
+
+bit_size(<<>>, Sz) -> Sz;
+bit_size(<<_:1, Bin/bitstring>>, Sz) -> bit_size(Bin, Sz+1).
+
+%%
+%% Simulate erlang:byte_size/1
+%%
+%% Calculates the size of a bitstring in bytes.
+%% Rounds up if the size is not divisible by 8.
+-spec byte_size(bitstring()) -> non_neg_integer().
+byte_size(<<>>) -> 0;
+byte_size(Bin) -> byte_size(Bin, 0, 1).
+
+byte_size(<<>>, _, Sz) ->
+  Sz;
+byte_size(<<_:1, Bin/bitstring>>, N, Sz) ->
+  case N of
+    8 -> byte_size(Bin, 1, Sz+1);
+    _ -> byte_size(Bin, N+1, Sz)
   end.

--- a/src/cuter_mock.erl
+++ b/src/cuter_mock.erl
@@ -57,6 +57,8 @@ simulate_behaviour(erlang, '-',             2) -> {ok, {cuter_erlang, '-',      
 simulate_behaviour(erlang, '*',             2) -> {ok, {cuter_erlang, '*',             2}};
 simulate_behaviour(erlang, '/',             2) -> {ok, {cuter_erlang, '/',             2}};
 simulate_behaviour(erlang, is_binary,       1) -> {ok, {cuter_erlang, is_binary,       1}};
+simulate_behaviour(erlang, bit_size,        1) -> {ok, {cuter_erlang, bit_size,        1}};
+simulate_behaviour(erlang, byte_size,       1) -> {ok, {cuter_erlang, byte_size,       1}};
 simulate_behaviour(erlang, _F, _A)        -> bif;
 
 %% cuter_erlang module

--- a/test/ftest/expected/bitstr-bit_sz-1.expected
+++ b/test/ftest/expected/bitstr-bit_sz-1.expected
@@ -1,0 +1,3 @@
+Testing bitstr:bit_sz/1 ...
+=== Inputs That Lead to Runtime Errors ===
+#1 bitstr:bit_sz(<<0:4>>)

--- a/test/ftest/expected/bitstr-byte_sz-1.expected
+++ b/test/ftest/expected/bitstr-byte_sz-1.expected
@@ -1,0 +1,3 @@
+Testing bitstr:byte_sz/1 ...
+=== Inputs That Lead to Runtime Errors ===
+#1 bitstr:byte_sz(<<0,0:1>>)

--- a/test/ftest/src/bitstr.erl
+++ b/test/ftest/src/bitstr.erl
@@ -130,3 +130,15 @@ f37(X) ->
     <<_:42>> -> error(not_ok);
     _ -> ok
   end.
+
+-spec byte_sz(bitstring()) -> ok.
+byte_sz(Bits) ->
+  case byte_size(Bits) of
+    Sz when Sz < 2 -> ok
+  end.
+
+-spec bit_sz(bitstring()) -> ok.
+bit_sz(Bits) ->
+  case bit_size(Bits) of
+    Sz when Sz < 4 -> ok
+  end.

--- a/test/functional_test
+++ b/test/functional_test
@@ -58,6 +58,8 @@ tests[47]="funs;f13b;[fun(_) -> 1 end, <<>>];25;${opts};funs-f13b-2;no-whitelist
 tests[48]="sum;classify;[[]];25;${opts} -pa ../lib/proper/ebin;sum-classify-1;no-whitelist"
 tests[49]="funs;f14;[fun(_) -> 1 end, []];25;${opts};funs-f14-2;no-whitelist"
 tests[50]="collection;eval_nif;[ok];25;${opts};collection-eval_nif-1;no-whitelist"
+tests[51]="bitstr;bit_sz;[<<>>];15;${opts};bitstr-bit_sz-1;no-whitelist"
+tests[52]="bitstr;byte_sz;[<<>>];42;${opts};bitstr-byte_sz-1;no-whitelist"
 
 for element in "${tests[@]}"; do
   IFS=';' read -a t <<< "$element"

--- a/test/utest/src/cuter_erlang_tests.erl
+++ b/test/utest/src/cuter_erlang_tests.erl
@@ -82,6 +82,8 @@ reversible_bifs_test_() ->
   , {"erlang:list_to_tuple/1 => cuter_erlang:list_to_tuple/1", prop_list_to_tuple(), 1000}
   , {"erlang:tuple_to_list/1 => cuter_erlang:tuple_to_list/1", prop_tuple_to_list(), 1000}
   , {"erlang:atom_to_list/1 => cuter_erlang:atom_to_list/1", prop_atom_to_list(), 1000}
+  , {"erlang:byte_size/1 => cuter_erlang:byte_size/1", prop_byte_size(), 4000}
+  , {"erlang:bit_size/1 => cuter_erlang:bit_size/1", prop_bit_size(), 4000}
   ],
   [{Descr, {timeout, 10000, ?_assert(proper:quickcheck(Prop, [{to_file, user}, {numtests, N}]))}} || {Descr, Prop, N} <- Props].
 
@@ -127,3 +129,11 @@ prop_tuple_to_list() ->
 -spec prop_atom_to_list() -> proper:outer_test().
 prop_atom_to_list() ->
   ?FORALL(X, atom(), atom_to_list(X) =:= cuter_erlang:atom_to_list(X)).
+
+-spec prop_byte_size() -> proper:outer_test().
+prop_byte_size() ->
+  ?FORALL(X, bitstring(), erlang:byte_size(X) =:= cuter_erlang:byte_size(X)).
+
+-spec prop_bit_size() -> proper:outer_test().
+prop_bit_size() ->
+  ?FORALL(X, bitstring(), erlang:bit_size(X) =:= cuter_erlang:bit_size(X)).


### PR DESCRIPTION
Support the BIFs `erlang:bit_size/1` and `erlang:byte_size/1`.

This pull request implements #64.