### PR TITLE
Support erlang:bnot/1 #71

### DIFF
--- a/src/cuter_erlang.erl
+++ b/src/cuter_erlang.erl
@@ -28,7 +28,7 @@
         , hd/1, tl/1
         , '++'/2, '--'/2, reverse/2, member/2, keyfind/3
         , is_binary/1, bit_size/1, byte_size/1
-        , 'bsl'/2, 'bsr'/2
+        , 'bsl'/2, 'bsr'/2, 'bnot'/1
         ]).
 
 %% XXX When adding type constraints for spec, the overriding funs must be ignored
@@ -976,3 +976,10 @@ bsr_h(X, N) ->
       X1 = safe_pos_div(X, 2),
       bsr_h(X1, N - 1)
   end.
+
+%%
+%% Simulate erlang:'bnot'/1
+%%
+%% Calculates the bitwise unary not of X.
+-spec 'bnot'(integer()) -> integer().
+'bnot'(X) -> -X-1.

--- a/src/cuter_mock.erl
+++ b/src/cuter_mock.erl
@@ -61,6 +61,7 @@ simulate_behaviour(erlang, bit_size,        1) -> {ok, {cuter_erlang, bit_size, 
 simulate_behaviour(erlang, byte_size,       1) -> {ok, {cuter_erlang, byte_size,       1}};
 simulate_behaviour(erlang, 'bsl',           2) -> {ok, {cuter_erlang, 'bsl',           2}};
 simulate_behaviour(erlang, 'bsr',           2) -> {ok, {cuter_erlang, 'bsr',           2}};
+simulate_behaviour(erlang, 'bnot',          1) -> {ok, {cuter_erlang, 'bnot',          1}};
 simulate_behaviour(erlang, _F, _A)        -> bif;
 
 %% cuter_erlang module

--- a/test/ftest/expected/bitstr-bnot_big-1.expected
+++ b/test/ftest/expected/bitstr-bnot_big-1.expected
@@ -1,0 +1,5 @@
+Testing bitstr:bnot_big/1 ...
+=== Inputs That Lead to Runtime Errors ===
+#1 bitstr:bnot_big(-1234567890123456789012345678901234567890123456789012345678901234567892)
+#2 bitstr:bnot_big(-123456789012345678901234567892)
+#3 bitstr:bnot_big(-123456789012347)

--- a/test/ftest/expected/bitstr-fbnot-1.expected
+++ b/test/ftest/expected/bitstr-fbnot-1.expected
@@ -1,0 +1,3 @@
+Testing bitstr:fbnot/1 ...
+=== Inputs That Lead to Runtime Errors ===
+#1 bitstr:fbnot(-43)

--- a/test/ftest/src/bitstr.erl
+++ b/test/ftest/src/bitstr.erl
@@ -180,3 +180,22 @@ bsr_big(X) ->
     Y when Y > XL -> error(bug3);
     _ -> ok
   end.
+
+-spec fbnot(integer()) -> ok.
+fbnot(X) ->
+  case bnot X of
+    42 -> error(bug);
+    _ -> ok
+  end.
+
+-spec bnot_big(integer()) -> ok.
+bnot_big(X) ->
+  M = 123456789012345,
+  L = 123456789012345678901234567890,
+  XL = 1234567890123456789012345678901234567890123456789012345678901234567890,
+  case bnot X of
+    Y when Y > M, Y < L -> error(bug1);
+    Y when Y > L, Y < XL -> error(bug2);
+    Y when Y > XL -> error(bug3);
+    _ -> ok
+  end.

--- a/test/functional_test
+++ b/test/functional_test
@@ -64,6 +64,8 @@ tests[53]="bitstr;fbsl;[1, 1];25;${opts};bitstr-fbsl-2;no-whitelist"
 tests[54]="bitstr;bsl_big;[1];100;${opts};bitstr-bsl_big-1;no-whitelist"
 tests[55]="bitstr;fbsr;[1, 1];25;${opts};bitstr-fbsr-2;no-whitelist"
 tests[56]="bitstr;bsr_big;[1];100;${opts};bitstr-bsr_big-1;no-whitelist"
+tests[57]="bitstr;fbnot;[1];25;${opts};bitstr-fbnot-1;no-whitelist"
+tests[58]="bitstr;bnot_big;[1];50;${opts};bitstr-bnot_big-1;no-whitelist"
 
 for element in "${tests[@]}"; do
   IFS=';' read -a t <<< "$element"

--- a/test/utest/src/cuter_erlang_tests.erl
+++ b/test/utest/src/cuter_erlang_tests.erl
@@ -86,6 +86,7 @@ reversible_bifs_test_() ->
   , {"erlang:bit_size/1 => cuter_erlang:bit_size/1", prop_bit_size(), 4000}
   , {"erlang:'bsl'/2 => cuter_erlang:'bsl'/2", prop_bsl(), 4000}
   , {"erlang:'bsr'/2 => cuter_erlang:'bsr'/2", prop_bsr(), 4000}
+  , {"erlang:'bnot'/1 => cuter_erlang:'bnot'/1", prop_bnot(), 4000}
   ],
   [{Descr, {timeout, 10000, ?_assert(proper:quickcheck(Prop, [{to_file, user}, {numtests, N}]))}} || {Descr, Prop, N} <- Props].
 
@@ -147,3 +148,7 @@ prop_bsl() ->
 -spec prop_bsr() -> proper:outer_test().
 prop_bsr() ->
   ?FORALL({X, Y}, {integer(), integer()}, (X bsr Y) =:= cuter_erlang:'bsr'(X, Y)).
+
+-spec prop_bnot() -> proper:outer_test().
+prop_bnot() ->
+  ?FORALL(X, integer(), erlang:'bnot'(X) =:= cuter_erlang:'bnot'(X)).


### PR DESCRIPTION
Support `erlang:'bnot'/1`.

This pull request implement #71.
