### PR TITLE
Fix issue #82

### DIFF
--- a/src/cuter_erlang.erl
+++ b/src/cuter_erlang.erl
@@ -222,6 +222,8 @@ safe_integer_to_list(I, Acc) ->
 
 -spec list_to_integer([43 | 45 | 48..57, ...]) -> integer().
 list_to_integer([]) -> erlang:error(badarg);
+list_to_integer([$-]) -> erlang:error(badarg);
+list_to_integer([$+]) -> erlang:error(badarg);
 list_to_integer([$-|L]) -> -1 * list_to_integer_10(L, 0);
 list_to_integer([$+|L]) -> list_to_integer_10(L, 0);
 list_to_integer(L) -> list_to_integer_10(L, 0).

--- a/test/ftest/src/collection.erl
+++ b/test/ftest/src/collection.erl
@@ -81,7 +81,7 @@ l2i(L) ->
 
 -spec l2in([45 | 43 | 48..57, ...]) -> ok.
 l2in(L) ->
-  case re:run(L, "^(\\+|-)?[0-9]*$") of
+  case re:run(L, "^(\\+|-)?[0-9]+$") of
     nomatch -> ok;
     _ ->
       case list_to_integer(L) of

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -814,8 +814,6 @@
             "errors": true,
             "whitelist": "collection-l2in-1",
             "solutions": [
-                "[\"+42\"]",
-                "[\"-42\"]",
                 "[\"42\"]"
             ]
         }


### PR DESCRIPTION
Minor fix.
Function cuter_erlang:list_to_integer/1 was taking strings "-" and "+" without an integer as valid inputs.
The test was also wrong.