### PR TITLE
Fix the overriding mfa of is_binary/1

### DIFF
--- a/src/cuter_erlang.erl
+++ b/src/cuter_erlang.erl
@@ -928,8 +928,9 @@ keyfind(Key, N, [H|T]) when is_tuple(H) ->
 %% BINARY / BITSTRING OPERATIONS
 %% ----------------------------------------------------------------------------
 
--spec is_binary(bitstring()) -> boolean().
-is_binary(Bin) -> is_binary(Bin, 0).
+-spec is_binary(any()) -> boolean().
+is_binary(Bin) when is_bitstring(Bin) -> is_binary(Bin, 0);
+is_binary(_) -> false.
 
 is_binary(<<>>, 0) -> true;
 is_binary(<<>>, _) -> false;

--- a/test/ftest/src/collection.erl
+++ b/test/ftest/src/collection.erl
@@ -1,5 +1,6 @@
 -module(collection).
--export([f/1, g/1, g1/1, h/1, f1/1, eval_nif/1, trunc1/1, trunc2/1, l2i/1, l2in/1]).
+-export([f/1, g/1, g1/1, h/1, f1/1, eval_nif/1, trunc1/1, trunc2/1, l2i/1, l2in/1,
+         to_upper/1]).
 
 -type t() :: [complex_spec:int()].
 
@@ -90,3 +91,19 @@ l2in(L) ->
         I when is_integer(I) -> ok
       end
   end.
+
+%% This testcase checks that given the below spec for the mfa, CutEr does not
+%% explore the path of the first clause.
+%% This behaviour was reported in Issue #86. It included a slightly different
+%% program and the error was related with the behaviour of erlang:is_binary/1.
+-spec to_upper(string()) -> string().
+to_upper(S) when is_binary(S) ->
+  error(bug);
+to_upper(S) when is_list(S) ->
+  [char_to_upper(C) || C <- S];
+to_upper(C) when is_integer(C) ->
+  char_to_upper(C).
+
+char_to_upper(16#0061) -> 16#0041;
+char_to_upper(16#0062) -> 16#0042;
+char_to_upper(C) -> C.

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -816,6 +816,13 @@
             "solutions": [
                 "[\"42\"]"
             ]
+        },
+        {
+            "module": "collection",
+            "function": "to_upper",
+            "args": "[[]]",
+            "depth": "7",
+            "errors": false
         }
     ]
 }


### PR DESCRIPTION
Make it a total function (as it should be) and allow
it to enter the manual calculation of whether a bitstring
is a binary only if it is actually a bitstring.

This pull request fixes #86.