### PR TITLE
Make the tests aware of the version of the underlying solver(s)

### DIFF
--- a/test/ftests.json
+++ b/test/ftests.json
@@ -6,9 +6,11 @@
             "args": "[0]",
             "depth": "9",
             "errors": true,
-            "solutions": [
-                "[42]"
-            ]
+            "solutions": {
+                "any": [
+                    "[42]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -16,9 +18,11 @@
             "args": "[0, 0, 0]",
             "depth": "14",
             "errors": true,
-            "solutions": [
-                "[0, 5, 2]"
-            ]
+            "solutions": {
+                "any": [
+                    "[0, 5, 2]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -26,9 +30,11 @@
             "args": "[0, 0, 0]",
             "depth": "24",
             "errors": true,
-            "solutions": [
-                "[3, 2, 3]", "[6, 3, 2]", "[26, 5, 0]"
-            ]
+            "solutions": {
+                "any": [
+                    "[3, 2, 3]", "[6, 3, 2]", "[26, 5, 0]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -36,9 +42,11 @@
             "args": "[<<>>]",
             "depth": "6",
             "errors": true,
-            "solutions": [
-                "[<<0,42:7>>]"
-            ]
+            "solutions": {
+                "any": [
+                    "[<<0,42:7>>]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -46,9 +54,11 @@
             "args": "[<<>>, 42]",
             "depth": "8",
             "errors": true,
-            "solutions": [
-                "[<<42:6>>, 6]"
-            ]
+            "solutions": {
+                "any": [
+                   "[<<42:6>>, 6]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -56,9 +66,11 @@
             "args": "[0, 0]",
             "depth": "7",
             "errors": true,
-            "solutions": [
-                "[9, 5]"
-            ]
+            "solutions": {
+                "any": [
+                   "[9, 5]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -66,9 +78,11 @@
             "args": "[<<>>, 0]",
             "depth": "8",
             "errors": true,
-            "solutions": [
-                "[<<42:6>>, 6]"
-            ]
+            "solutions": {
+                "any": [
+                   "[<<42:6>>, 6]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -76,9 +90,11 @@
             "args": "[<<>>, 0]",
             "depth": "8",
             "errors": true,
-            "solutions": [
-                "[<<42:6>>, 6]"
-            ]
+            "solutions": {
+                "any": [
+                   "[<<42:6>>, 6]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -86,9 +102,11 @@
             "args": "[<<>>, 0]",
             "depth": "10",
             "errors": true,
-            "solutions": [
-                "[<<\"*\">>, 8]", "[<<42:6>>, 6]"
-            ]
+            "solutions": {
+                "any": [
+                   "[<<\"*\">>, 8]", "[<<42:6>>, 6]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -103,9 +121,11 @@
             "args": "[<<>>, 0]",
             "depth": "6",
             "errors": true,
-            "solutions": [
-                "[<<0:4>>, 0]"
-            ]
+            "solutions": {
+                "any": [
+                    "[<<0:4>>, 0]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -113,9 +133,11 @@
             "args": "[<<>>, 0, 3]",
             "depth": "11",
             "errors": true,
-            "solutions": [
-                "[<<64,3:3>>, 0, 0]"
-            ]
+            "solutions": {
+                "any": [
+                    "[<<64,3:3>>, 0, 0]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -123,9 +145,11 @@
             "args": "[<<>>, 0, 0, <<>>]",
             "depth": "21",
             "errors": true,
-            "solutions": [
-                "[<<0:1>>, 0, 0, <<0:1>>]"
-            ]
+            "solutions": {
+                "any": [
+                    "[<<0:1>>, 0, 0, <<0:1>>]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -154,9 +178,11 @@
             "args": "[<<>>]",
             "depth": "50",
             "errors": true,
-            "solutions": [
-                "[<<0,0,0,0,0,0:2>>]"
-            ]
+            "solutions": {
+                "any": [
+                    "[<<0,0,0,0,0,0:2>>]"
+                ]
+            }
         },
         {
             "module": "otp_int",
@@ -164,9 +190,11 @@
             "args": "[erlang, length, 1]",
             "depth": "3",
             "errors": true,
-            "solutions": [
-                "[ssl, negotiated_next_protocol, 1]"
-            ]
+            "solutions": {
+                "any": [
+                    "[ssl, negotiated_next_protocol, 1]"
+                ]
+            }
         },
         {
             "module": "whitelist",
@@ -175,9 +203,11 @@
             "depth": "3",
             "whitelist": "whitelist-f-1",
             "errors": true,
-            "solutions": [
-                "[424242]"
-            ]
+            "solutions": {
+                "any": [
+                    "[424242]"
+                ]
+            }
         },
         {
             "module": "whitelist",
@@ -186,9 +216,11 @@
             "depth": "3",
             "whitelist": "whitelist-g-1",
             "errors": true,
-            "solutions": [
-                "[4242]"
-            ]
+            "solutions": {
+                "any": [
+                    "[4242]"
+                ]
+            }
         },
         {
             "module": "whitelist",
@@ -197,9 +229,11 @@
             "depth": "3",
             "whitelist": "whitelist-k-1",
             "errors": true,
-            "solutions": [
-                "[42]"
-            ]
+            "solutions": {
+                "any": [
+                    "[42]"
+                ]
+            }
         },
         {
             "module": "complex_spec",
@@ -207,9 +241,11 @@
             "args": "[[]]",
             "depth": "32",
             "errors": true,
-            "solutions": [
-                "[[{[1,2],[{[[1],[2]],[3.14]},2]}]]"
-            ]
+            "solutions": {
+                "any": [
+                    "[[{[1,2],[{[[1],[2]],[3.14]},2]}]]"
+                ]
+            }
         },
         {
             "module": "collection",
@@ -217,9 +253,11 @@
             "args": "[[]]",
             "depth": "10",
             "errors": true,
-            "solutions": [
-                "[[17,17,42]]"
-            ]
+            "solutions": {
+                "any": [
+                    "[[17,17,42]]"
+                ]
+            }
         },
         {
             "module": "collection",
@@ -227,9 +265,11 @@
             "args": "[1]",
             "depth": "2",
             "errors": true,
-            "solutions": [
-                "[42]", "[[0]]", "[\"*\"]"
-            ]
+            "solutions": {
+                "any": [
+                    "[42]", "[[0]]", "[\"*\"]"
+                ]
+            }
         },
         {
             "module": "collection",
@@ -237,9 +277,11 @@
             "args": "[1]",
             "depth": "2",
             "errors": true,
-            "solutions": [
-                "[42]", "[1]", "[[0]]"
-            ]
+            "solutions": {
+                "any": [
+                    "[42]", "[1]", "[[0]]"
+                ]
+            }
         },
         {
             "module": "collection",
@@ -247,9 +289,11 @@
             "args": "[1]",
             "depth": "2",
             "errors": true,
-            "solutions": [
-                "[17]"
-            ],
+            "solutions": {
+                "any": [
+                    "[17]"
+                ]
+            },
             "bifs": [
                 "erlang:get/1"
             ]
@@ -261,9 +305,11 @@
             "depth": "4",
             "errors": true,
             "withUtestBin": true,
-            "solutions": [
-                "[38.86]"
-            ]
+            "solutions": {
+                "any": [
+                    "[38.86]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -271,9 +317,11 @@
             "args": "[fun(_) -> 1 end]",
             "depth": "2",
             "errors": true,
-            "solutions": [
-                "[fun(3) -> 42; (10) -> 17; (_) -> 42 end]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(3) -> 42; (10) -> 17; (_) -> 42 end]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -281,9 +329,11 @@
             "args": "[fun(_) -> 1 end, 0, 0]",
             "depth": "2",
             "errors": true,
-            "solutions": [
-                "[fun(2) -> 42; (3) -> 17; (_) -> 42 end, 2, 3]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(2) -> 42; (3) -> 17; (_) -> 42 end, 2, 3]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -291,9 +341,11 @@
             "args": "[fun(_) -> 1 end, 0, 0]",
             "depth": "2",
             "errors": true,
-            "solutions": [
-                "[fun(5) -> 17; (2) -> 4; (4) -> 42; (3) -> 5; (_) -> 17 end, 2, 3]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(5) -> 17; (2) -> 4; (4) -> 42; (3) -> 5; (_) -> 17 end, 2, 3]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -301,10 +353,16 @@
             "args": "[fun(_) -> fun(_) -> 1 end end, 0, 0]",
             "depth": "2",
             "errors": true,
-            "solutions": [
-                "[fun(_) -> 4 end, 2, 3]",
-                "[fun(_) -> fun(_) -> 42 end end, 2, 3]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_) -> 4 end, 2, 3]",
+                    "[fun(_) -> fun(_) -> 42 end end, 2, 3]"
+                ],
+                "z3-4.4.2": [
+                    "[fun(_) -> 0.0 end, 2, 3]",
+                    "[fun(_) -> fun(_) -> 42 end end, 2, 3]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -312,11 +370,18 @@
             "args": "[fun(_) -> fun(_) -> 1 end end, 0, 0]",
             "depth": "2",
             "errors": true,
-            "solutions": [
-                "[fun(_) -> 4 end, 2, 3]",
-                "[fun(_) -> {4, 5} end, 2, 3]",
-                "[fun(_) -> fun(_) -> 42 end end, 2, 3]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_) -> 4 end, 2, 3]",
+                    "[fun(_) -> {4, 5} end, 2, 3]",
+                    "[fun(_) -> fun(_) -> 42 end end, 2, 3]"
+                ],
+                "z3-4.4.2": [
+                    "[fun(_) -> 0.0 end, 2, 3]",
+                    "[fun(_) -> {0.0, 1.0} end, 2, 3]",
+                    "[fun(_) -> fun(_) -> 42 end end, 2, 3]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -324,9 +389,11 @@
             "args": "[fun(_,_,_) -> 1 end, 0, 0, 0]",
             "depth": "2",
             "errors": true,
-            "solutions": [
-                "[fun(4,2,1) -> 17; (1,2,4) -> 42; (_,_,_) -> 17 end, 1, 2, 4]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(4,2,1) -> 17; (1,2,4) -> 42; (_,_,_) -> 17 end, 1, 2, 4]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -334,15 +401,17 @@
             "args": "[0]",
             "depth": "15",
             "errors": true,
-            "solutions": [
-                "[42]",
-                "[fun(_) -> 42 end]",
-                "[fun(_) -> fun(_) -> 42 end end]",
-                "[fun(_) -> fun(_) -> fun(_) -> 42 end end end]",
-                "[fun(_) -> fun(_) -> fun(_) -> fun(_) -> 42 end end end end]",
-                "[fun(_) -> fun(_) -> fun(_) -> fun(_) -> fun(_) -> 42 end end end end end]",
-                "[fun(_) -> fun(_) -> fun(_) -> fun(_) -> fun(_) -> fun(_) -> 42 end end end end end end]"
-            ]
+            "solutions": {
+                "any": [
+                    "[42]",
+                    "[fun(_) -> 42 end]",
+                    "[fun(_) -> fun(_) -> 42 end end]",
+                    "[fun(_) -> fun(_) -> fun(_) -> 42 end end end]",
+                    "[fun(_) -> fun(_) -> fun(_) -> fun(_) -> 42 end end end end]",
+                    "[fun(_) -> fun(_) -> fun(_) -> fun(_) -> fun(_) -> 42 end end end end end]",
+                    "[fun(_) -> fun(_) -> fun(_) -> fun(_) -> fun(_) -> fun(_) -> 42 end end end end end end]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -350,10 +419,12 @@
             "args": "[fun(_,_) -> 1 end, []]",
             "depth": "6",
             "errors": true,
-            "solutions": [
-                "[fun(_,_) -> 42 end, [3]]",
-                "[fun(3,0) -> 5; (4,5) -> 42; (_,_) -> 5 end, [3,4]]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_,_) -> 42 end, [3]]",
+                    "[fun(3,0) -> 5; (4,5) -> 42; (_,_) -> 5 end, [3,4]]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -361,10 +432,16 @@
             "args": "[fun(_) -> true end, [1]]",
             "depth": "4",
             "errors": true,
-            "solutions": [
-                "[fun(_) -> false end, [2]]",
-                "[fun(_) -> true end, []]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_) -> false end, [2]]",
+                    "[fun(_) -> true end, []]"
+                ],
+                "z3-4.4.2": [
+                    "[fun(_) -> false end, [0.0]]",
+                    "[fun(_) -> true end, []]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -373,11 +450,18 @@
             "depth": "4",
             "opts": "-p 1 -s 1",
             "errors": true,
-            "solutions": [
-                "[fun(_) -> 3 end, 1, 2]",
-                "[fun(_) -> 42 end, 2, 1]",
-                "[fun(_,_) -> 42 end, 1, 2]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_) -> 3 end, 1, 2]",
+                    "[fun(_) -> 42 end, 2, 1]",
+                    "[fun(_,_) -> 42 end, 1, 2]"
+                ],
+                "z3-4.4.2": [
+                    "[fun(_) -> 42 end, 0.0, 1]",
+                    "[fun(_) -> fun(_) -> 0 end end, 1, 2]",
+                    "[fun(_,_) -> 42 end, 0.0, 2]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -385,11 +469,18 @@
             "args": "[fun(_) -> 1 end, 1]",
             "depth": "4",
             "errors": true,
-            "solutions": [
-                "[fun() -> 3 end, 1]",
-                "[fun(_) -> 42 end, 2]",
-                "[fun(_,_) -> 42 end, 1]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun() -> 3 end, 1]",
+                    "[fun(_) -> 42 end, 2]",
+                    "[fun(_,_) -> 42 end, 1]"
+                ],
+                "z3-4.4.2": [
+                    "[fun() -> fun() -> 0 end end, 1]",
+                    "[fun(_) -> 42 end, 0.0]",
+                    "[fun(_,_) -> 42 end, 0.0]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -397,9 +488,11 @@
             "args": "[fun(_) -> 1 end]",
             "depth": "4",
             "errors": true,
-            "solutions": [
-                "[fun(_) -> 42 end]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_) -> 42 end]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -407,14 +500,24 @@
             "args": "[fun(_) -> fun(_) -> 1 end end, fun(_) -> fun(_) -> 1 end end, 1]",
             "depth": "4",
             "errors": true,
-            "solutions": [
-                "[fun(_) -> 6 end, fun(_) -> 5 end, 1]",
-                "[fun(_) -> fun(_) -> 0.0 end end, fun(_) -> fun(_) -> [] end end, 9]",
-                "[fun(_) -> fun(_) -> 10 end end, fun(_) -> 4 end, 6]",
-                "[fun(_) -> fun(_) -> 7719 end end, fun(_) -> fun(_) -> -7710 end end, 10]",
-                "[fun(_) -> fun(_) -> [] end end, fun(_) -> fun(_) -> 10 end end, 5]",
-                "[fun(_) -> fun(_) -> [] end end, fun(_) -> fun(_) -> [] end end, 9]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_) -> 6 end, fun(_) -> 5 end, 1]",
+                    "[fun(_) -> fun(_) -> 0.0 end end, fun(_) -> fun(_) -> [] end end, 9]",
+                    "[fun(_) -> fun(_) -> 10 end end, fun(_) -> 4 end, 6]",
+                    "[fun(_) -> fun(_) -> 7719 end end, fun(_) -> fun(_) -> -7710 end end, 10]",
+                    "[fun(_) -> fun(_) -> [] end end, fun(_) -> fun(_) -> 10 end end, 5]",
+                    "[fun(_) -> fun(_) -> [] end end, fun(_) -> fun(_) -> [] end end, 9]"
+                ],
+                "z3-4.4.2": [
+                    "[fun(_) -> 6 end, fun(_) -> fun(_) -> 0 end end, 1]",
+                    "[fun(_) -> fun(_) -> 0.0 end end, fun(_) -> fun(_) -> [] end end, 1.0]",
+                    "[fun(_) -> fun(_) -> 8 end end, fun(_) -> 0.0 end, 1.0]",
+                    "[fun(_) -> fun(_) -> 7719 end end, fun(_) -> fun(_) -> -7710 end end, 0.0]",
+                    "[fun(_) -> fun(_) -> [] end end, fun(_) -> fun(_) -> 9 end end, 0.0]",
+                    "[fun(_) -> fun(_) -> [] end end, fun(_) -> fun(_) -> [] end end, 0.0]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -422,10 +525,16 @@
             "args": "[fun(_) -> fun(_) -> 1 end end]",
             "depth": "4",
             "errors": true,
-            "solutions": [
-                "[fun(_) -> 3 end]",
-                "[fun(_) -> fun(_) -> 42 end end]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_) -> 3 end]",
+                    "[fun(_) -> fun(_) -> 42 end end]"
+                ],
+                "z3-4.4.2": [
+                    "[fun(_) -> 0.0 end]",
+                    "[fun(_) -> fun(_) -> 42 end end]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -461,9 +570,11 @@
             "args": "[fun(_) -> 1 end]",
             "depth": "2",
             "errors": true,
-            "solutions": [
-                "[fun(3) -> 42; (10) -> 17; (_) -> 42 end]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(3) -> 42; (10) -> 17; (_) -> 42 end]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -471,9 +582,11 @@
             "args": "[fun(_) -> 1 end, {}]",
             "depth": "5",
             "errors": true,
-            "solutions": [
-                "[fun(_) -> 3 end, {4,2}]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_) -> 3 end, {4,2}]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -481,10 +594,12 @@
             "args": "[fun(_) -> 1 end, <<>>]",
             "depth": "25",
             "errors": true,
-            "solutions": [
-                "[fun(_) -> 1 end, <<5>>]",
-                "[fun(_) -> 10 end, <<5:6>>]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_) -> 1 end, <<5>>]",
+                    "[fun(_) -> 10 end, <<5:6>>]"
+                ]
+            }
         },
         {
             "module": "sum",
@@ -493,9 +608,11 @@
             "depth": "25",
             "withProper": true,
             "errors": true,
-            "solutions": [
-                "[[-5450,8365,1796]]", "[[2437,2274]]", "[[4711]]", "[[4711.0]]"
-            ]
+            "solutions": {
+                "any": [
+                    "[[-5450,8365,1796]]", "[[2437,2274]]", "[[4711]]", "[[4711.0]]"
+                ]
+            }
         },
         {
             "module": "funs",
@@ -503,9 +620,11 @@
             "args": "[fun(_) -> 1 end, []]",
             "depth": "25",
             "errors": true,
-            "solutions": [
-                "[fun(_) -> [1, 2, 3] end, [4]]"
-            ]
+            "solutions": {
+                "any": [
+                    "[fun(_) -> [1, 2, 3] end, [4]]"
+                ]
+            }
         },
         {
             "module": "collection",
@@ -520,9 +639,11 @@
             "args": "[<<>>]",
             "depth": "15",
             "errors": true,
-            "solutions": [
-                "[<<0:4>>]"
-            ]
+            "solutions": {
+                "any": [
+                    "[<<0:4>>]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -530,9 +651,11 @@
             "args": "[<<>>]",
             "depth": "42",
             "errors": true,
-            "solutions": [
-                "[<<0,0:1>>]"
-            ]
+            "solutions": {
+                "any": [
+                    "[<<0,0:1>>]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -540,9 +663,11 @@
             "args": "[1, 1]",
             "depth": "25",
             "errors": true,
-            "solutions": [
-                "[21, 1]", "[42, 0]", "[84, -1]", "[168, -2]"
-            ]
+            "solutions": {
+                "any": [
+                    "[21, 1]", "[42, 0]", "[84, -1]", "[168, -2]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -550,11 +675,13 @@
             "args": "[1]",
             "depth": "100",
             "errors": true,
-            "solutions": [
-                "[7716049313272]",
-                "[7716049313271604931327160494]",
-                "[77160493132716049313271604931327160493132716049313271604931327160494]"
-            ]
+            "solutions": {
+                "any": [
+                    "[7716049313272]",
+                    "[7716049313271604931327160494]",
+                    "[77160493132716049313271604931327160493132716049313271604931327160494]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -562,9 +689,11 @@
             "args": "[1, 1]",
             "depth": "25",
             "errors": true,
-            "solutions": [
-                "[21, -1]", "[42, 0]", "[84, 1]", "[168, 2]"
-            ]
+            "solutions": {
+                "any": [
+                    "[21, -1]", "[42, 0]", "[84, 1]", "[168, 2]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -572,11 +701,13 @@
             "args": "[1]",
             "depth": "100",
             "errors": true,
-            "solutions": [
-                "[1975308624197536]",
-                "[1975308624197530862419753086256]",
-                "[19753086241975308624197530862419753086241975308624197530862419753086256]"
-            ]
+            "solutions": {
+                "any": [
+                    "[1975308624197536]",
+                    "[1975308624197530862419753086256]",
+                    "[19753086241975308624197530862419753086241975308624197530862419753086256]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -584,9 +715,11 @@
             "args": "[1]",
             "depth": "25",
             "errors": true,
-            "solutions": [
-                "[-43]"
-            ]
+            "solutions": {
+                "any": [
+                    "[-43]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -594,11 +727,13 @@
             "args": "[1]",
             "depth": "50",
             "errors": true,
-            "solutions": [
-                "[-1234567890123456789012345678901234567890123456789012345678901234567892]",
-                "[-123456789012345678901234567892]",
-                "[-123456789012347]"
-            ]
+            "solutions": {
+                "any": [
+                    "[-1234567890123456789012345678901234567890123456789012345678901234567892]",
+                    "[-123456789012345678901234567892]",
+                    "[-123456789012347]"
+                ]
+            }
         },
         {
             "module": "collection",
@@ -606,9 +741,11 @@
             "args": "[1]",
             "depth": "25",
             "errors": true,
-            "solutions": [
-                "[2.75]"
-            ]
+            "solutions": {
+                "any": [
+                    "[2.75]"
+                ]
+            }
         },
         {
             "module": "collection",
@@ -616,9 +753,11 @@
             "args": "[1]",
             "depth": "25",
             "errors": true,
-            "solutions": [
-                "[-42.75]"
-            ]
+            "solutions": {
+                "any": [
+                    "[-42.75]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -627,9 +766,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[-115245587226975570856629698659936890834, 115244775925639664041776219450078580218]"
-            ]
+            "solutions": {
+                "any": [
+                    "[-115245587226975570856629698659936890834, 115244775925639664041776219450078580218]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -638,9 +779,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[-10, -34]"
-            ]
+            "solutions": {
+                "any": [
+                    "[-10, -34]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -649,9 +792,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[1267650600228229401496703205376, 1267650600228229401496703205376]"
-            ]
+            "solutions": {
+                "any": [
+                    "[1267650600228229401496703205376, 1267650600228229401496703205376]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -660,9 +805,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[-1298114088876869206436467930326479, -1227781192769208556173848975922]"
-            ]
+            "solutions": {
+                "any": [
+                    "[-1298114088876869206436467930326479, -1227781192769208556173848975922]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -671,9 +818,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[-10722113295479264474453651513181749953, -25081040589696498295982299549491773275]"
-            ]
+            "solutions": {
+                "any": [
+                    "[-10722113295479264474453651513181749953, -25081040589696498295982299549491773275]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -682,9 +831,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[8098239615821597375497340003855403778, 8098239615821597375497340003855403816]"
-            ]
+            "solutions": {
+                "any": [
+                    "[8098239615821597375497340003855403778, 8098239615821597375497340003855403816]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -693,9 +844,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[10746391985634429997612810101056519776, 10746391985634429997612967280874891538]"
-            ]
+            "solutions": {
+                "any": [
+                    "[10746391985634429997612810101056519776, 10746391985634429997612967280874891538]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -704,9 +857,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[3714386857363838068689887652, 1317963678609701630637856821312]"
-            ]
+            "solutions": {
+                "any": [
+                    "[3714386857363838068689887652, 1317963678609701630637856821312]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -715,9 +870,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[154038586524071506316860854678694172406, -154038586524071506316860854678694172384]"
-            ]
+            "solutions": {
+                "any": [
+                    "[154038586524071506316860854678694172406, -154038586524071506316860854678694172384]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -726,9 +883,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[132438649102067967026620554223683666340, -132438649102067967026620960032741791446]"
-            ]
+            "solutions": {
+                "any": [
+                    "[132438649102067967026620554223683666340, -132438649102067967026620960032741791446]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -737,9 +896,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[-148528931426514002676418943389977804784, 148528930104835937209353474683431095820]"
-            ]
+            "solutions": {
+                "any": [
+                    "[-148528931426514002676418943389977804784, 148528930104835937209353474683431095820]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -748,9 +909,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[34, 8]"
-            ]
+            "solutions": {
+                "any": [
+                    "[34, 8]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -759,9 +922,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[576531571286646856, 78123050067394816]"
-            ]
+            "solutions": {
+                "any": [
+                    "[576531571286646856, 78123050067394816]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -770,9 +935,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[46598350958186933355168341451912384804, 85569455391686265217897127254634324160]"
-            ]
+            "solutions": {
+                "any": [
+                    "[46598350958186933355168341451912384804, 85569455391686265217897127254634324160]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -781,9 +948,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[-122858486675391948889053936672818495856, 122858486675391948889053938871841751405]"
-            ]
+            "solutions": {
+                "any": [
+                    "[-122858486675391948889053936672818495856, 122858486675391948889053938871841751405]"
+                ]
+            }
         },
         {
             "module": "bitstr",
@@ -792,9 +961,11 @@
             "depth": "25",
             "errors": true,
             "validate": true,
-            "solutions": [
-                "[-127665441727703630643001662293994373054, 127665439146605058293920069946395660416]"
-            ]
+            "solutions": {
+                "any": [
+                    "[-127665441727703630643001662293994373054, 127665439146605058293920069946395660416]"
+                ]
+            }
         },
         {
             "module": "collection",
@@ -802,9 +973,11 @@
             "args": "[[49]]",
             "depth": "70",
             "errors": true,
-            "solutions": [
-                "[\"42\"]"
-            ]
+            "solutions": {
+                "any": [
+                    "[\"42\"]"
+                ]
+            }
         },
         {
             "module": "collection",
@@ -813,9 +986,11 @@
             "depth": "80",
             "errors": true,
             "whitelist": "collection-l2in-1",
-            "solutions": [
-                "[\"42\"]"
-            ]
+            "solutions": {
+                "any": [
+                    "[\"42\"]"
+                ]
+            }
         },
         {
             "module": "collection",

--- a/test/functional_test
+++ b/test/functional_test
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import json, multiprocessing, os, re, sys
+import json, multiprocessing, os, re, sys, z3
 from subprocess import Popen, PIPE
 from pprint import pprint
 
@@ -16,87 +16,136 @@ defaultOpts = "-p {} -s {}".format(nCores, nCores * 2)
 separator = "=== Inputs That Lead to Runtime Errors ==="
 bifSeparator = "=== BIFs Currently without Symbolic Interpretation ==="
 
+def solver_version():
+    # Get Z3's version
+    (vA, vB, vC, _) = z3.get_version()
+    z3_version = "z3-{}.{}.{}".format(vA, vB, vC)
+    return z3_version
+
 def getExpectedFile(test):
-  return os.path.join(testDir, "ftest", "expected", test["expected"] + ".expected")
+    return os.path.join(testDir, "ftest", "expected", test["expected"] + ".expected")
 
 def printOutputAndExit(out):
-  print "OUTPUT MISMATCH"
-  print "================================================================="
-  print out.strip()
-  print "================================================================="
-  sys.exit(1)
+    print "OUTPUT MISMATCH"
+    print "================================================================="
+    print out.strip()
+    print "================================================================="
+    sys.exit(1)
 
-with open(testsJson) as fd:
-  tests = json.load(fd)["tests"]
-
-  for i, test in enumerate(tests):
-    # Set the default values for optional parameters.
-    for param in ["withUtestBin", "validate", "withProper"]:
-      if not param in test:
-        test[param] = False
-    # Get the runtime options.
-    opts = test["opts"] if "opts" in test else defaultOpts
-    # Get the whitelist.
+def extra_opts(test, testDir, ftestEbin, utestEbin, properEbin):
+    extraOpts = ""
     if "whitelist" in test:
-      whitelist = os.path.join(testDir, "ftest", "whitelist", test["whitelist"] + ".txt")
-      opts += " -w {}".format(whitelist)
-    # Add the extra paths.
+        whitelist = os.path.join(testDir, "ftest", "whitelist", test["whitelist"] + ".txt")
+        extraOpts += " -w {}".format(whitelist)
     extraPaths = [ftestEbin]
     if test["withUtestBin"]:
-      extraPaths.append(utestEbin)
+        extraPaths.append(utestEbin)
     if test["withProper"]:
-      extraPaths.append(properEbin)
-    opts += " -pa {}".format(" ".join(extraPaths))
-    # Run the test.
-    cmd = "{} {} {} '{}' -d {} {} --sorted-errors".format(
-      cuterScript, test["module"], test["function"], test["args"], test["depth"], opts
-    )
-    print "\n[Test #{}]\n{}".format(i + 1, cmd)
-    if "skip" in test and test["skip"]:
-      print "Skipping ..."
-      continue
-    p = Popen(cmd, stdin=PIPE, stdout=PIPE, shell=True)
-    output, err = p.communicate()
-    # Validate the presence of errors or not.
+        extraPaths.append(properEbin)
+    extraOpts += " -pa {}".format(" ".join(extraPaths))
+    return extraOpts
+
+def check_errors_presence_and_get_interesting(test, output, separator):
+    """
+    Checks if there should be errors found.
+    Returns the interesting part of the inputs
+    """
     parts = output.strip().split(separator)
     if test["errors"]:
-      if len(parts) != 2:
-        printOutputAndExit(output)
+        if len(parts) != 2:
+            printOutputAndExit(output)
+        return parts[1]
     else:
-      if len(parts) != 1:
+        if len(parts) != 1:
+            printOutputAndExit(output)
+
+def check_unsupported_bifs(test, interesting):
+    """
+    Gets the unsupported BIFs section from the interesting output
+    and checks it against the expected unsupported BIFs.
+    Then returns the rest of the interesting output.
+    """
+    if not "bifs" in test:
+        return interesting
+    bifs = test["bifs"]
+    bifParts = interesting.split(bifSeparator)
+    bifFound = bifParts[1].strip().split("\n")
+    if len(bifFound) != len(bifs):
         printOutputAndExit(output)
-      else:
-        continue
-    interesting = parts[1]
-    # Validate the BIFs.
-    if "bifs" in test:
-      bifs = test["bifs"]
-      bifParts = interesting.split(bifSeparator)
-      interesting = bifParts[0].strip()
-      bifParts = bifParts[1].strip().split("\n")
-      if len(bifParts) != len(bifs):
+    if set([bif.strip() for bif in bifFound]) != set(bifs):
         printOutputAndExit(output)
-      if set([bif.strip() for bif in bifParts]) != set(bifs):
+    return bifParts[0].strip()
+
+def get_found_errors(test, interesting):
+    """
+    Extracts the found errors from the interesting part of the output.
+    """
+    errors = interesting.strip().split("\n")
+    found = set(["[" + re.search(r"\((.*)\)", sol).group(1) + "]" for sol in errors])
+    # The number of errors should be the same in all versions.
+    if len(found) != len(test["solutions"]["any"]):
         printOutputAndExit(output)
-    # Validate the number of errors found.
-    solutions = interesting.strip().split("\n")
-    found = set(["[" + re.search(r"\((.*)\)", sol).group(1) + "]" for sol in solutions])
-    if len(found) != len(test["solutions"]):
-      printOutputAndExit(output)
-    expected = set(test["solutions"])
-    # Validate the errors found.
-    if not test["validate"]:
-      # Simply check if found the expected errors.
-      if found != expected:
-        printOutputAndExit(output)
-    else:
-      # Validate that every error is actually an error.
-      for sol in found:
+    return found
+
+def get_expected_errors(test):
+    """
+    Gets the expected errors.
+    Is aware of the version of the underlying solver(s).
+    """
+    version = solver_version()
+    sols = test["solutions"]
+    return set(sols[version]) if version in sols else set(sols["any"])
+
+def validate_errors(test, found, ftestEbin, output):
+    """
+    Checks that every error is actually an error.
+    """
+    for sol in found:
         mfaCall = "{}:{}({})".format(test["module"], test["function"], sol[1:-1])
         cmd = "erl -noshell -pa {} -eval \"{}\" -s init stop".format(ftestEbin, mfaCall)
         p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
         out, err = p.communicate()
         if p.returncode != 1:
-          printOutputAndExit(output)
+            printOutputAndExit(output)
 
-  sys.exit(0)
+
+with open(testsJson) as fd:
+    tests = json.load(fd)["tests"]
+
+    for i, test in enumerate(tests):
+        # Set the default values for optional parameters.
+        for param in ["withUtestBin", "validate", "withProper"]:
+            if not param in test:
+                test[param] = False
+        # Get the runtime options.
+        opts = test["opts"] if "opts" in test else defaultOpts
+        opts += extra_opts(test, testDir, ftestEbin, utestEbin, properEbin)
+        # Run the test.
+        cmd = "{} {} {} '{}' -d {} {} --sorted-errors".format(
+          cuterScript, test["module"], test["function"], test["args"], test["depth"], opts
+        )
+        print "\n[Test #{}]\n{}".format(i + 1, cmd)
+        if "skip" in test and test["skip"]:
+            print "Skipping ..."
+            continue
+        p = Popen(cmd, stdin=PIPE, stdout=PIPE, shell=True)
+        output, err = p.communicate()
+        # Validate the presence of errors or not.
+        interesting = check_errors_presence_and_get_interesting(test, output, separator)
+        if not test["errors"]:
+            continue
+        # Validate the unsupported BIFs.
+        interesting = check_unsupported_bifs(test, interesting)
+        # Validate the number of errors found.
+        found = get_found_errors(test, interesting)
+        expected = get_expected_errors(test)
+        # Validate the errors found.
+        if not test["validate"]:
+            # Simply check if found the expected errors.
+            if found != expected:
+                printOutputAndExit(output)
+        else:
+            # Validate that every error is actually an error.
+            validate_errors(test, found, ftestEbin, output)
+
+    sys.exit(0)


### PR DESCRIPTION
The tests now work with Z3 v4.4.2.

This PR fixes #94.
