### PR TITLE
Support Recursive types

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -146,7 +146,7 @@ suite: utest_target ftest_target
 
 test: utest ftest
 
-all: $(TARGETS) dialyzer utest ftest z3py-ftest
+all: $(TARGETS) dialyzer utest ftest
 
 cuter_target: $(SRC_MODULES:%=$(EBIN)/%.beam) $(PROTOBUFS:%=$(EBIN)/%.beam) $(PROTOBUFS:%=$(PRIV)/%_pb2.py)
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -190,10 +190,10 @@ utest: $(TARGETS)
 	@(python $(TEST)/terms.py)
 
 ftest: $(TARGETS)
-	@(./$(TEST)/functional_test)
+	@(./$(TEST)/functional_test --no=$(no))
 
 z3py-ftest: $(TARGETS)
-	@(./$(TEST)/functional_test --z3py)
+	@(./$(TEST)/functional_test --no=$(no) --z3py)
 
 dialyzer: .plt/.cuter_plt cuter_target
 	dialyzer --plt $< $(DIALYZER_FLAGS) $(EBIN)/*.beam

--- a/include/cuter_types.hrl
+++ b/include/cuter_types.hrl
@@ -24,3 +24,4 @@
 -define(local_tag, local).
 -define(record_tag, record).
 -define(function_tag, function).
+-define(userdef_tag, userdef).

--- a/priv/cuter_common.py
+++ b/priv/cuter_common.py
@@ -385,6 +385,13 @@ def get_model_entries(model_data):
 # Manipulate Spec objects.
 # =============================================================================
 
+def get_type_defs_of_spec(spec):
+    """
+    Parameters
+        spec : Spec
+    """
+    return spec.typedefs
+
 def get_spec_clauses(spec):
     """
     Parameters
@@ -782,3 +789,32 @@ def is_type_ntuple(t):
         t : Spec.Type
     """
     return t.type == Spec.NTUPLE
+
+def is_type_userdef(t):
+    """
+    Parameters
+        t : Spec.Type
+    """
+    return t.type == Spec.USERDEF
+
+def get_type_name_of_userdef(t):
+    """
+    Parameters
+        t : Spec.Type
+    """
+    assert t.type == Spec.USERDEF
+    return t.type_name
+
+def get_typedef_name(tdef):
+    """
+    Parameters
+        tdef : Spec.TypeDef
+    """
+    return tdef.name
+
+def get_typedef_definition(tdef):
+    """
+    Parameters
+        tdef : Spec.TypeDef
+    """
+    return tdef.definition

--- a/priv/cuter_smt.py
+++ b/priv/cuter_smt.py
@@ -205,6 +205,14 @@ class ErlangSMT(cgs.AbstractErlangSolver):
 		"""
 		Store the spec of the entry point MFA.
 		"""
+		typedefs = cc.get_type_defs_of_spec(spec)
+		if len(typedefs) > 0:
+			# TODO First define the rec funs for the typedefs (all of them together).
+			for tdf in typedefs:
+				tname = cc.get_typedef_name(tdf)
+				clg.debug_info("typedef name: " + str(tname))
+				tdefinition = cc.get_typedef_definition(tdf)
+				clg.debug_info("typedef definition: " + str(tdefinition))
 		p = cc.get_spec_clauses(spec)[0]
 		pms = cc.get_parameters_from_complete_funsig(p)
 		for item in zip(self.vars, pms):
@@ -350,6 +358,10 @@ class ErlangSMT(cgs.AbstractErlangSolver):
 			return ["=", var, self.decode(cc.get_literal_from_atomlit(spec))]
 		elif cc.is_type_integerlit(spec):
 			return ["=", var, self.decode(cc.get_literal_from_integerlit(spec))]
+		elif cc.is_type_userdef(spec):
+			type_name = cc.get_type_name_of_userdef(spec)
+			# TODO Refer to defined rec fun for the type.
+			return "true"
 		clg.debug_info("unknown spec: " + str(spec))
 		assert False
 

--- a/src/cuter_codeserver.erl
+++ b/src/cuter_codeserver.erl
@@ -219,12 +219,13 @@ handle_call({get_spec, {M, F, A}=MFA}, _From, State) ->
         {ok, CerlSpec} ->
           DepMods = load_all_deps_of_spec(CerlSpec, M, MDb, State),
           Fn = fun(Mod) ->
-		   {ok, ModDb} = try_load(Mod, State),
-		   StoredTypes = cuter_cerl:get_stored_types(ModDb),
-		   {Mod, StoredTypes}
-	       end,
+              {ok, ModDb} = try_load(Mod, State),
+              StoredTypes = cuter_cerl:get_stored_types(ModDb),
+              {Mod, StoredTypes}
+            end,
           ManyStoredTypes = [Fn(Mod) || Mod <- DepMods],
           Parsed = cuter_types:parse_spec(MFA, CerlSpec, ManyStoredTypes),
+          cuter_pp:parsed_spec(Parsed),
           {reply, {ok, Parsed}, State}
       end;
     Msg ->

--- a/src/cuter_proto_spec.proto
+++ b/src/cuter_proto_spec.proto
@@ -22,6 +22,12 @@ message Spec {
         FUN = 14;
         CONS = 15;
         NTUPLE = 16;
+        USERDEF = 17;
+    }
+
+    message TypeDef {
+        string name = 1;
+        Type definition = 2;
     }
 
     message RangeBounds {
@@ -56,6 +62,7 @@ message Spec {
             TypeList inner_types = 6;
             FunSig fun = 7;
             uint32 ntuple_size = 8;
+            string type_name = 9;
         }
     }
 
@@ -64,4 +71,5 @@ message Spec {
     }
 
     repeated FunSig clauses = 1;
+    repeated TypeDef typedefs = 2;
 }

--- a/test/ftest/src/collection.erl
+++ b/test/ftest/src/collection.erl
@@ -1,6 +1,6 @@
 -module(collection).
 -export([f/1, g/1, g1/1, h/1, f1/1, eval_nif/1, trunc1/1, trunc2/1, l2i/1, l2in/1,
-         to_upper/1, k/2, k2/3, p/1, a2l/1, test_alias/1]).
+         to_upper/1, k/2, k2/3, p/1, a2l/1, test_alias/1, fclist/1]).
 
 -type t() :: [complex_spec:int()].
 
@@ -149,4 +149,14 @@ test_alias(X) ->
   case hd(Y) of
       5 -> error(bug);
       _ -> ok
+  end.
+
+-type clist() :: nil | {integer(), clist()}.
+
+-spec fclist(clist()) -> ok.
+fclist(X) ->
+  case X of
+    1 -> error(unreachable_bug);
+    {42, {17, nil}} -> error(bug);
+    _ -> ok
   end.

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -278,7 +278,7 @@
             "solutions": [
                 "$1[0:3] == [17, 17, 42]"
             ],
-            "skip": false
+            "skip": true
         },
         {
             "module": "collection",

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -278,7 +278,7 @@
             "solutions": [
                 "$1[0:3] == [17, 17, 42]"
             ],
-            "skip": true
+            "skip": false
         },
         {
             "module": "collection",
@@ -1081,6 +1081,18 @@
             "arity": 1,
             "solutions": [
                 "[5]"
+            ],
+            "skip": false
+        },
+        {
+            "module": "collection",
+            "function": "fclist",
+            "args": "[nil]",
+            "depth": "10",
+            "errors": true,
+            "arity": 1,
+            "solutions": [
+                "[{42,{17,nil}}]"
             ],
             "skip": false
         }

--- a/test/functional_test
+++ b/test/functional_test
@@ -6,13 +6,15 @@ from pprint import pprint
 from types import *
 import terms
 
-def run(testDir, z3py):
+def run(testDir, z3py, n):
     baseDir = get_basedir(testDir)
     cuterScript = os.path.join(baseDir, "cuter")
     separator = "=== Inputs That Lead to Runtime Errors ==="
     bifSeparator = "=== BIFs Currently without Symbolic Interpretation ==="
 
     for i, test in enumerate(get_tests(testDir)):
+        if n is not None and n != i + 1:
+            continue
         # Set the default values for optional parameters.
         for param in ["withUtestBin", "validate", "withProper"]:
             if not param in test:
@@ -140,6 +142,9 @@ def printOutputAndExit(out):
 
 if __name__ == "__main__":
     z3py = "--z3py" in sys.argv
+    xs = map(int, filter(None,
+        filter(lambda x: x.startswith("--no="), sys.argv)[0].split("--no=")))
+    n = xs[0] if len(xs) > 0 else None
     testDir = os.path.dirname(os.path.realpath(__file__))
-    run(testDir, z3py)
+    run(testDir, z3py, n)
     sys.exit(0)

--- a/test/utest/src/cuter_codeserver_tests.erl
+++ b/test/utest/src/cuter_codeserver_tests.erl
@@ -53,15 +53,16 @@ get_spec_test_() ->
     Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
     %% types_and_specs:foo/0
     Spec0 = cuter_codeserver:retrieve_spec(Cs, {types_and_specs, foo, 0}),
-    Expected0 = [cuter_types:t_function([], cuter_types:t_atom_lit(ok))],
+    Expected0 = {[cuter_types:t_function([], cuter_types:t_atom_lit(ok))], []},
     %% types_and_specs:f11/1, f12/1
     Spec11 = cuter_codeserver:retrieve_spec(Cs, {types_and_specs, f11, 1}),
     Spec12 = cuter_codeserver:retrieve_spec(Cs, {types_and_specs, f12, 1}),
-    Expected1 = [cuter_types:t_function([cuter_types:t_float()], cuter_types:t_float())],
+    T1 = cuter_types:unique_type_name(types_and_specs, t6, []),
+    Expected1 = [cuter_types:t_function([cuter_types:t_userdef(T1)], cuter_types:t_float())],
     Stop = cuter_codeserver:stop(Cs),
     [ {"types_and_specs:foo/0", ?_assertEqual({ok, Expected0}, Spec0)}
-    , {"types_and_specs:f11/1", ?_assertEqual({ok, Expected1}, Spec11)}
-    , {"types_and_specs:f12/1", ?_assertEqual({ok, Expected1}, Spec12)}
+    , {"types_and_specs:f11/1", ?_assertEqual(Expected1, element(1, element(2, Spec11)))}
+    , {"types_and_specs:f12/1", ?_assertEqual(Expected1, element(1, element(2, Spec12)))}
     , {"codeserver termination", ?_assertEqual(ok, Stop)}
     ]
   end,

--- a/test/utest/src/cuter_iserver_tests.erl
+++ b/test/utest/src/cuter_iserver_tests.erl
@@ -23,6 +23,7 @@ start_stop_test_() ->
 setup() ->
   process_flag(trap_exit, true),
   Dir = cuter_tests_lib:setup_dir(),
+  ok = cuter_pp:start(cuter_pp:default_reporting_level()),
   CodeServer = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
   Server = cuter_iserver:start(lists, reverse, [[42,17]], Dir, ?TRACE_DEPTH, CodeServer),
   {Dir, Server}.
@@ -33,5 +34,7 @@ cleanup({Dir, Server}) ->
   after
     5000 -> ok
   end,
+  cuter_pp:stop(),
+  timer:sleep(200),
   cuter_lib:clear_and_delete_dir(Dir).
 

--- a/test/utest/src/cuter_serial_tests.erl
+++ b/test/utest/src/cuter_serial_tests.erl
@@ -201,5 +201,5 @@ encode_spec_test_() ->
   [{"Serialize specs: " ++ C, {setup, Setup(T), Inst}} || {C, T} <- Ts].
 
 encode_spec(Spec) ->
-  cuter_serial:to_log_entry('OP_SPEC', [Spec], false, 0),
+  cuter_serial:to_log_entry('OP_SPEC', [{Spec, []}], false, 0),
   [].


### PR DESCRIPTION
This PR will allow CutEr to reason over recursive types.

Remaining tasks:
- [x] Support by the solver backend.
- [ ] Normalize type / spec definitions.
- [x] Add tests for recursive types.