### PR TITLE
Normalize Types

### DIFF
--- a/cuter
+++ b/cuter
@@ -27,6 +27,7 @@ def main():
   parser.add_argument("--disable-pmatch", action='store_true', help="disable the pattern matching compilation")
   parser.add_argument("--sorted-errors", action='store_true', help="report the erroneous inputs in a sorted order")
   parser.add_argument("--suppress-unsupported", action='store_true', help="suppresses the reporting of unsupported MFAs")
+  parser.add_argument("--no-type-normalization", action='store_true', help="disable the normalization specifications & types")
   parser.add_argument("--z3py", action='store_true', help="use the z3py solver backend")
 
   # Parse the arguments
@@ -84,6 +85,8 @@ def main():
     opts.append("sorted_errors")
   if args.suppress_unsupported:
     opts.append("suppress_unsupported")
+  if args.no_type_normalization:
+    opts.append("no_type_normalization")
   if args.w != None:
       opts.append("{{whitelist, '{}'}}".format(args.w))
   if args.z3py:

--- a/src/cuter.erl
+++ b/src/cuter.erl
@@ -41,6 +41,7 @@
 -define(CALCULATE_COVERAGE, coverage).
 -define(SORTED_ERRORS, sorted_errors).
 -define(SUPPRESS_UNSUPPORTED_MFAS, suppress_unsupported).
+-define(NO_TYPE_NORMALIZATION, no_type_normalization).
 -define(Z3PY, z3py).
 
 -type default_option() :: {?POLLERS_NO, ?ONE}
@@ -57,6 +58,7 @@
                 | ?CALCULATE_COVERAGE
                 | ?SORTED_ERRORS
                 | ?SUPPRESS_UNSUPPORTED_MFAS
+                | ?NO_TYPE_NORMALIZATION
                 | ?Z3PY
                 .
 
@@ -200,7 +202,8 @@ initialize_app(M, F, As, Depth, Options) ->
   WithPmatch = with_pmatch(Options),
   SolverBackend = get_solver_backend(Options),
   Whitelist = get_whitelist(Options),
-  CodeServer = cuter_codeserver:start(self(), WithPmatch, Whitelist),
+  NormalizeTypes = type_normalization(Options),
+  CodeServer = cuter_codeserver:start(self(), WithPmatch, Whitelist, NormalizeTypes),
   SchedPid = cuter_scheduler_maxcover:start(SolverBackend, Depth, As, CodeServer),
   cuter_pp:mfa({M, F, length(As)}),
   #conf{ codeServer = CodeServer
@@ -283,3 +286,6 @@ sort_errors(Options) -> lists:member(?SORTED_ERRORS, Options).
 
 -spec suppress_unsupported_mfas([option()]) -> boolean().
 suppress_unsupported_mfas(Options) -> lists:member(?SUPPRESS_UNSUPPORTED_MFAS, Options).
+
+-spec type_normalization([option()]) -> boolean().
+type_normalization(Options) -> not lists:member(?NO_TYPE_NORMALIZATION, Options).

--- a/src/cuter_codeserver.erl
+++ b/src/cuter_codeserver.erl
@@ -5,22 +5,22 @@
 -behaviour(gen_server).
 
 %% external exports
--export([start/3, start/5, stop/1, load/2, unsupported_mfa/2, retrieve_spec/2,
-	 get_feasible_tags/2, get_logs/1, get_whitelist/1, get_visited_tags/1,
-	 visit_tag/2, calculate_callgraph/2,
+-export([start/4, start/6, stop/1, load/2, unsupported_mfa/2, retrieve_spec/2,
+         get_feasible_tags/2, get_logs/1, get_whitelist/1, get_visited_tags/1,
+         visit_tag/2, calculate_callgraph/2,
          %% Work with module cache
          merge_dumped_cached_modules/2, modules_of_dumped_cache/1,
-	 lookup_in_module_cache/2, insert_in_module_cache/3,
-	 no_cached_modules/0,
+         lookup_in_module_cache/2, insert_in_module_cache/3,
+         no_cached_modules/0,
          %% Access logs
          cachedMods_of_logs/1, visitedTags_of_logs/1, tagsAddedNo_of_logs/1,
          unsupportedMfas_of_logs/1, loadedMods_of_logs/1]).
 %% gen_server callbacks
 -export([init/1, terminate/2, code_change/3,
-	 handle_info/2, handle_call/3, handle_cast/2]).
+         handle_info/2, handle_call/3, handle_cast/2]).
 %% Counter of branches & Tag generator.
 -export([set_branch_counter/1, get_branch_counter/0, initial_branch_counter/0,
-	 generate_tag/0]).
+         generate_tag/0]).
 
 -include("include/cuter_macros.hrl").
 
@@ -90,7 +90,8 @@
   workers = []                 :: [pid()],
   unsupportedMfas = sets:new() :: sets:set(mfa()),
   whitelist                    :: cuter_mock:whitelist(),
-  callgraph                    :: cuter_callgraph:callgraph() | 'undefined'
+  callgraph                    :: cuter_callgraph:callgraph() | 'undefined',
+  normalizeTypes               :: boolean()
 }).
 -type state() :: #st{}.
 
@@ -99,15 +100,15 @@
 %% ----------------------------------------------------------------------------
 
 %% Starts a CodeServer in the local node.
--spec start(pid(), boolean(), cuter_mock:whitelist()) -> pid().
-start(Super, WithPmatch, Whitelist) ->
-  start(Super, no_cached_modules(), initial_branch_counter(), WithPmatch, Whitelist).
+-spec start(pid(), boolean(), cuter_mock:whitelist(), boolean()) -> pid().
+start(Super, WithPmatch, Whitelist, NormalizeTypes) ->
+  start(Super, no_cached_modules(), initial_branch_counter(), WithPmatch, Whitelist, NormalizeTypes).
 
 %% Starts a CodeServer in the local node with an initialized
 %% modules' cache and tag counter.
--spec start(pid(), cached_modules(), counter(), boolean(), cuter_mock:whitelist()) -> pid().
-start(Super, StoredMods, TagsN, WithPmatch, Whitelist) ->
-  case gen_server:start(?MODULE, [Super, StoredMods, TagsN, WithPmatch, Whitelist], []) of
+-spec start(pid(), cached_modules(), counter(), boolean(), cuter_mock:whitelist(), boolean()) -> pid().
+start(Super, StoredMods, TagsN, WithPmatch, Whitelist, NormalizeTypes) ->
+  case gen_server:start(?MODULE, [Super, StoredMods, TagsN, WithPmatch, Whitelist, NormalizeTypes], []) of
     {ok, CodeServer} -> CodeServer;
     {error, Reason}  -> exit({codeserver_start, Reason})
   end.
@@ -172,7 +173,7 @@ get_feasible_tags(CodeServer, NodeTypes) ->
 
 %% gen_server callback : init/1
 -spec init([pid() | cached_modules() | counter() | boolean() | cuter_mock:whitelist(), ...]) -> {ok, state()}.
-init([Super, CachedMods, TagsN, WithPmatch, Whitelist]) ->
+init([Super, CachedMods, TagsN, WithPmatch, Whitelist, NormalizeTypes]) ->
   link(Super),
   Db = ets:new(?MODULE, [ordered_set, protected]),
   add_cached_modules(Db, CachedMods),
@@ -180,7 +181,8 @@ init([Super, CachedMods, TagsN, WithPmatch, Whitelist]) ->
   {ok, #st{ db = Db
           , super = Super
           , withPmatch = WithPmatch
-          , whitelist = Whitelist}}.
+          , whitelist = Whitelist
+          , normalizeTypes = NormalizeTypes}}.
 
 %% gen_server callback : terminate/2
 -spec terminate(any(), state()) -> ok.
@@ -209,7 +211,7 @@ handle_info(_Msg, State) ->
                .
 handle_call({load, M}, _From, State) ->
   {reply, try_load(M, State), State};
-handle_call({get_spec, {M, F, A}=MFA}, _From, State) ->
+handle_call({get_spec, {M, F, A}=MFA}, _From, State=#st{normalizeTypes = NormalizeTypes}) ->
   case try_load(M, State) of
     {ok, MDb} ->
       case cuter_cerl:retrieve_spec(MDb, {F, A}) of
@@ -224,7 +226,7 @@ handle_call({get_spec, {M, F, A}=MFA}, _From, State) ->
               {Mod, StoredTypes}
             end,
           ManyStoredTypes = [Fn(Mod) || Mod <- DepMods],
-          Parsed = cuter_types:parse_spec(MFA, CerlSpec, ManyStoredTypes),
+          Parsed = cuter_types:parse_spec(MFA, CerlSpec, ManyStoredTypes, NormalizeTypes),
           cuter_pp:parsed_spec(Parsed),
           {reply, {ok, Parsed}, State}
       end;

--- a/src/cuter_codeserver.erl
+++ b/src/cuter_codeserver.erl
@@ -211,7 +211,7 @@ handle_info(_Msg, State) ->
                .
 handle_call({load, M}, _From, State) ->
   {reply, try_load(M, State), State};
-handle_call({get_spec, {M, F, A}=MFA}, _From, State=#st{normalizeTypes = NormalizeTypes}) ->
+handle_call({get_spec, {M, F, A}=MFA}, _From, #st{normalizeTypes = NormalizeTypes}=State) ->
   case try_load(M, State) of
     {ok, MDb} ->
       case cuter_cerl:retrieve_spec(MDb, {F, A}) of

--- a/src/cuter_types.erl
+++ b/src/cuter_types.erl
@@ -2,7 +2,7 @@
 %%------------------------------------------------------------------------------
 -module(cuter_types).
 
--export([parse_spec/3, retrieve_types/1, retrieve_specs/1, find_spec/2, get_kind/1,
+-export([parse_spec/4, retrieve_types/1, retrieve_specs/1, find_spec/2, get_kind/1,
          find_remote_deps_of_type/2, find_remote_deps_of_spec/2]).
 
 -export([params_of_t_function_det/1, ret_of_t_function/1, atom_of_t_atom_lit/1, integer_of_t_integer_lit/1,
@@ -804,15 +804,124 @@ maybe_hash_args(Ps, Args) ->
   Ps ++ [integer_to_list(Arity), integer_to_list(erlang:phash2(Args))].
 
 %% ----------------------------------------------------------------------------
+%% Normalize parsed specs & type dependencies
+%% ----------------------------------------------------------------------------
+
+normalize_type_deps(Deps) ->
+  Seen = ets:new(?MODULE, [ordered_set, protected]),
+  NormalizedDeps = normalize_type_deps(Deps, Seen, []),
+  ets:delete(Seen),
+  NormalizedDeps.
+
+normalize_type_deps([], _Seen, Acc) ->
+  lists:reverse(Acc);
+normalize_type_deps([{TypeName, Type}|Types], Seen, Acc) ->
+  {NormalizedType, MoreDeps} = normalize_single_type(Type, Seen, true),
+  Acc1 = lists:reverse(MoreDeps) ++ Acc,
+  normalize_type_deps(Types, Seen, [{TypeName, NormalizedType}|Acc1]).
+
+normalize_single_type(#t{kind = ?function_tag, rep = {Params, Ret, _}}=Type, Seen, IsTopLevel) ->
+  case ets:lookup(Seen, Type) of
+    [{Type, Handle}] ->
+      {Handle, []};
+    [] ->
+      Xs = [normalize_single_type(T, Seen, false) || T <- [Ret|Params]],
+      {Ts, Deps} = lists:unzip(Xs),
+      NormalizedType = Type#t{rep = {tl(Ts), hd(Ts), []}},
+      AllDeps = lists:flatten(lists:map(fun lists:reverse/1, Deps)),
+      case IsTopLevel of
+        true ->
+          {NormalizedType, AllDeps};
+        false ->
+          NewTypeName = generate_new_type(),
+          NewType = t_userdef(NewTypeName),
+          Dep = {NewTypeName, NormalizedType},
+          true = ets:insert(Seen, {NormalizedType, NewType}),
+          {NewType, [Dep|AllDeps]}
+      end
+  end;
+normalize_single_type(#t{kind = ?function_tag, rep = {Ret, _}}=Type, Seen, IsTopLevel) ->
+  case ets:lookup(Seen, Type) of
+    [{Type, Handle}] ->
+      {Handle, []};
+    [] ->
+      {T, Deps} = normalize_single_type(Ret, Seen, false),
+      NormalizedType = Type#t{rep = {T, []}},
+      case IsTopLevel of
+        true ->
+          {NormalizedType, Deps};
+        false ->
+          NewTypeName = generate_new_type(),
+          NewType = t_userdef(NewTypeName),
+          Dep = {NewTypeName, NormalizedType},
+          true = ets:insert(Seen, {NormalizedType, NewType}),
+          {NewType, [Dep|Deps]}
+      end
+  end;
+%% list / nonempty_list
+normalize_single_type(#t{kind = Tag, rep = InnerType}=Type, Seen, IsTopLevel) when Tag =:= ?list_tag; Tag =:= ?nonempty_list_tag ->
+  case ets:lookup(Seen, Type) of
+    [{Type, Handle}] ->
+      {Handle, []};
+    [] ->
+      {T, Deps} = normalize_single_type(InnerType, Seen, false),
+      NormalizedType = Type#t{rep = T},
+      case IsTopLevel of
+        true ->
+          {NormalizedType, Deps};
+        false ->
+          NewTypeName = generate_new_type(),
+          NewType = t_userdef(NewTypeName),
+          Dep = {NewTypeName, NormalizedType},
+          true = ets:insert(Seen, {NormalizedType, NewType}),
+          {NewType, [Dep|Deps]}
+      end
+  end;
+%% union or tuple
+normalize_single_type(#t{kind = Tag, rep = InnerTypes}=Type, Seen, IsTopLevel) when Tag =:= ?union_tag; Tag =:= ?tuple_tag ->
+  case ets:lookup(Seen, Type) of
+    [{Type, Handle}] ->
+      {Handle, []};
+    [] ->
+      Xs = [normalize_single_type(T, Seen, false) || T <- InnerTypes],
+      {Ts, Deps} = lists:unzip(Xs),
+      NormalizedType = Type#t{rep = Ts},
+      AllDeps = lists:flatten(lists:map(fun lists:reverse/1, Deps)),
+      case IsTopLevel of
+        true ->
+          {NormalizedType, AllDeps};
+        false ->
+          NewTypeName = generate_new_type(),
+          NewType = t_userdef(NewTypeName),
+          Dep = {NewTypeName, NormalizedType},
+          true = ets:insert(Seen, {NormalizedType, NewType}),
+          {NewType, [Dep|AllDeps]}
+      end
+  end;
+%% all others
+normalize_single_type(Raw, _Seen, _IsTopLevel) ->
+  {Raw, []}.
+
+generate_new_type() ->
+  "tp@" ++ erlang:ref_to_list(erlang:make_ref()) -- "#Ref<>".
+
+%% ----------------------------------------------------------------------------
 %% Traverse a spec and substitute the local and remote types.
 %% ----------------------------------------------------------------------------
 
--spec parse_spec(mfa(), stored_spec_value(), many_stored_types()) -> erl_spec().
-parse_spec(Mfa, Spec, ManyStoredTypes) ->
+-spec parse_spec(mfa(), stored_spec_value(), many_stored_types(), boolean()) -> erl_spec().
+parse_spec(Mfa, Spec, ManyStoredTypes, NormalizeTypes) ->
   Conf = mk_conf(Mfa, ManyStoredTypes),
-  Parsed = parse_spec_clauses(Spec, Conf, []),
+  {ParsedSpec, Deps} = parse_spec_clauses(Spec, Conf, []),
   true = cleanup_conf(Conf),
-  Parsed.
+  %% TODO Maybe also normalize the parsed spec.
+  case NormalizeTypes of
+    false ->
+      {ParsedSpec, Deps};
+    true ->
+      NormalizedDeps = normalize_type_deps(Deps),
+      {ParsedSpec, NormalizedDeps}
+  end.
 
 parse_spec_clauses([], Conf, Acc) ->
   {lists:reverse(Acc), parse_type_deps(Conf)};

--- a/test/ftest/src/collection.erl
+++ b/test/ftest/src/collection.erl
@@ -1,6 +1,6 @@
 -module(collection).
 -export([f/1, g/1, g1/1, h/1, f1/1, eval_nif/1, trunc1/1, trunc2/1, l2i/1, l2in/1,
-         to_upper/1, k/2, k2/3, p/1, a2l/1, test_alias/1, fclist/1]).
+         to_upper/1, k/2, k2/3, p/1, a2l/1, test_alias/1, fclist/1, fweird/1]).
 
 -type t() :: [complex_spec:int()].
 
@@ -158,5 +158,15 @@ fclist(X) ->
   case X of
     1 -> error(unreachable_bug);
     {42, {17, nil}} -> error(bug);
+    _ -> ok
+  end.
+
+-type weird() :: ok | [integer() | weird()].
+
+-spec fweird(weird()) -> ok.
+fweird(X) ->
+  case X of
+    1 -> error(unreachable_bug);
+    [42, [ok], [17, ok, ok, [1, 2]]] -> error(bug);
     _ -> ok
   end.

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -259,13 +259,13 @@
             "module": "complex_spec",
             "function": "f",
             "args": "[[]]",
-            "depth": "32",
+            "depth": "35",
             "errors": true,
             "arity": 1,
             "solutions": [
                 "[[{[1,2],[{[[1],[2]],[3.14]},2]}]]"
             ],
-            "skip": true
+            "skip": false
         },
         {
             "module": "collection",
@@ -1091,8 +1091,21 @@
             "depth": "10",
             "errors": true,
             "arity": 1,
+            "opts": "--no-type-normalization",
             "solutions": [
                 "[{42,{17,nil}}]"
+            ],
+            "skip": false
+        },
+        {
+            "module": "collection",
+            "function": "fweird",
+            "args": "[ok]",
+            "depth": "25",
+            "errors": true,
+            "arity": 1,
+            "solutions": [
+                "[[42,[ok],[17,ok,ok,[1,2]]]]"
             ],
             "skip": false
         }

--- a/test/utest/src/cuter_codeserver_tests.erl
+++ b/test/utest/src/cuter_codeserver_tests.erl
@@ -15,7 +15,7 @@ load_modules_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
   Inst = fun(_) ->
-    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
+    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist(), true),
     As = [load_mod(Cs, M) || M <- ?MODS_LIST],
     Stop = cuter_codeserver:stop(Cs),
     [{"codeserver termination", ?_assertEqual(ok, Stop)},
@@ -33,7 +33,7 @@ load_and_retrieve_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
   Inst = fun(_) ->
-    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
+    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist(), true),
     R1 = cuter_codeserver:load(Cs, lists),
     R2 = cuter_codeserver:load(Cs, os),
     R3 = cuter_codeserver:load(Cs, lists),
@@ -50,7 +50,7 @@ get_spec_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
   Inst = fun(_) ->
-    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
+    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist(), true),
     %% types_and_specs:foo/0
     Spec0 = cuter_codeserver:retrieve_spec(Cs, {types_and_specs, foo, 0}),
     Expected0 = {[cuter_types:t_function([], cuter_types:t_atom_lit(ok))], []},
@@ -74,7 +74,7 @@ error_load_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
   Inst = fun(_) ->
-    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
+    Cs = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist(), true),
     R1 = cuter_codeserver:load(Cs, erlang),
     R2 = cuter_codeserver:load(Cs, foobar),
     Stop = cuter_codeserver:stop(Cs),

--- a/test/utest/src/cuter_eval_tests.erl
+++ b/test/utest/src/cuter_eval_tests.erl
@@ -40,7 +40,7 @@ eval_cerl_test_() ->
   [{"Basic Cerl Evaluation: " ++ C, {setup, Setup(I), Cleanup, Inst}} || {C, I} <- Is].
 
 eval_cerl({F, As, Result, Dir}) ->
-  CodeServer = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
+  CodeServer = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist(), true),
   Server = cuter_iserver:start(?MODULE, F, As, Dir, ?TRACE_DEPTH, CodeServer),
   R = execution_result(Server),
   ok = wait_for_iserver(Server),

--- a/test/utest/src/cuter_iserver_tests.erl
+++ b/test/utest/src/cuter_iserver_tests.erl
@@ -24,7 +24,7 @@ setup() ->
   process_flag(trap_exit, true),
   Dir = cuter_tests_lib:setup_dir(),
   ok = cuter_pp:start(cuter_pp:default_reporting_level()),
-  CodeServer = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist()),
+  CodeServer = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist(), true),
   Server = cuter_iserver:start(lists, reverse, [[42,17]], Dir, ?TRACE_DEPTH, CodeServer),
   {Dir, Server}.
 


### PR DESCRIPTION
The point of this MR is to normalize function specifications and type definitions to facilitate SMT solving.

This works well with intricate specs, like `complex_spec:f/1`, but leads to timeouts in some cases, like `collection:fclist/1`.
So I've added a flag to disable this optimization, if needed.