### PR TITLE
Comment out encoding of refs and pids for the time being

### DIFF
--- a/src/cuter_serial.erl
+++ b/src/cuter_serial.erl
@@ -185,12 +185,17 @@ encode_term(T, Seen) when is_tuple(T) ->
   Ts = tuple_to_list(T),
   Subterms = [encode_maybe_shared_term(X, Seen) || X <- Ts],
   #'ErlangTerm'{type='TUPLE', subterms=Subterms};
-%% pid
-encode_term(Pid, _Seen) when is_pid(Pid) ->
-  #'ErlangTerm'{type='PID', value=pid_to_list(Pid)};
-%% reference
-encode_term(Ref, _Seen) when is_reference(Ref) ->
-  #'ErlangTerm'{type='REFERENCE', value=erlang:ref_to_list(Ref)};
+%%%
+%%% TODO: Uncomment out these clauses when it is decided how to
+%%% properly handle pids and refs.  Also, make sure that the
+%%% corresponding unit tests are re-enabled.
+%%%
+%% %% pid
+%% encode_term(Pid, _Seen) when is_pid(Pid) ->
+%%   #'ErlangTerm'{type='PID', value=pid_to_list(Pid)};
+%% %% reference
+%% encode_term(Ref, _Seen) when is_reference(Ref) ->
+%%   #'ErlangTerm'{type='REFERENCE', value=erlang:ref_to_list(Ref)};
 %% bitstring & binary
 encode_term(Ref, _Seen) when is_bitstring(Ref) ->
   Bits = encode_bitstring(Ref),
@@ -208,7 +213,7 @@ encode_term(M, Seen) when is_map(M) ->
 encode_term(Term, _Seen) ->
   case cuter_lib:is_lambda(Term) of
     %% fun (cuter_lib:lambda())
-    %% TODO Use the same Seen set.
+    %% TODO: Use the same Seen set.
     true ->
       Points = cuter_lib:lambda_kvs(Term),
       Otherwise = cuter_lib:lambda_default(Term),

--- a/test/utest/src/cuter_serial_tests.erl
+++ b/test/utest/src/cuter_serial_tests.erl
@@ -38,13 +38,13 @@ encdec_test_() ->
       {"Simple", {1,2,3}},
       {"With shared subterms", {1,2,{1,2},{3,1,2},{1,2}}}
     ]},
-    {"PIDs", [
-      {"Self", self()},
-      {"Group leader", erlang:group_leader()}
-    ]},
-    {"References", [
-      {"Make reference", erlang:make_ref()}
-    ]},
+    %% {"PIDs", [
+    %%   {"Self", self()},
+    %%   {"Group leader", erlang:group_leader()}
+    %% ]},
+    %% {"References", [
+    %%   {"Make reference", erlang:make_ref()}
+    %% ]},
     {"Bitstrings", [
       {"binary", <<42>>},
       {"bitstring", <<42:42>>}
@@ -74,7 +74,7 @@ encode_decode(Terms) ->
   [{Descr, ?_assertEqual(maybe(T), Dec(Enc(T)))} || {Descr, T} <- Terms].
 
 %% Special case for reference().
-maybe(Rf) when is_reference(Rf) -> erlang:ref_to_list(Rf);
+%% maybe(Rf) when is_reference(Rf) -> erlang:ref_to_list(Rf);
 maybe(T) -> T.
 
 %% Serializing unsupported terms tests.
@@ -94,7 +94,7 @@ enc_fail_test_() ->
 encdec_cmd_test_() ->
   Cs = [
     {"I", {'OP_PARAMS', [cuter_symbolic:fresh_symbolic_var(), cuter_symbolic:fresh_symbolic_var()]}},
-    {"II", {'OP_MATCH_EQUAL_FALSE', [cuter_symbolic:fresh_symbolic_var(), erlang:make_ref()]}},
+    {"II", {'OP_MATCH_EQUAL_FALSE', [cuter_symbolic:fresh_symbolic_var()]}},	%% , erlang:make_ref()]}},
     {"III", {'OP_PARAMS', [cuter_symbolic:fresh_symbolic_var(), 42]}},
     {"IV", {'OP_CONS', [cuter_symbolic:fresh_symbolic_var(), cuter_symbolic:fresh_symbolic_var(), [<<"false">>]]}}
   ],


### PR DESCRIPTION
Also comment out the corresponding tests until we decide what
is the proper way to handle these terms in the solver.

This fixes the SOLVER ERROR crash reported in #120.