### PR TITLE
Add constraints on encoding flags of bitstrings

### DIFF
--- a/test/ftest/src/bitstr.erl
+++ b/test/ftest/src/bitstr.erl
@@ -1,13 +1,14 @@
 -module(bitstr).
 
 -export([f11/1, f12/3, f13/3, f13a/3,
-	 f21/1, f22/2, f23/2, f24/2, f24a/2, f25/2, f26/2, f27/2,
-	 f31/2, f32/3, f33/4, f34/2, f35/1, f36/1, f37/1,
-	 fbit_sz/1, fbyte_sz/1,
-	 fbsl/2, fbsl_big/1, fbsr/2, fbsr_big/1, fbnot/1, fbnot_big/1,
-	 fband/2, fband2/2, fband_neg/2, fband3/2, fband2_neg/2,
-	 fbxor/2, fbxor2/2, fbxor3/2, fbxor_neg/2, fbxor2_neg/2, fbxor3_neg/2,
-	 fbor/2, fbor2/2, fbor3/2, fbor_neg/2, fbor2_neg/2]).
+         f21/1, f22/2, f23/2, f24/2, f24a/2, f25/2, f26/2, f27/2,
+         f31/2, f32/3, f33/4, f34/2, f35/1, f36/1, f37/1,
+         fbit_sz/1, fbyte_sz/1,
+         fbsl/2, fbsl_big/1, fbsr/2, fbsr_big/1, fbnot/1, fbnot_big/1,
+         fband/2, fband2/2, fband_neg/2, fband3/2, fband2_neg/2,
+         fbxor/2, fbxor2/2, fbxor3/2, fbxor_neg/2, fbxor2_neg/2, fbxor3_neg/2,
+         fbor/2, fbor2/2, fbor3/2, fbor_neg/2, fbor2_neg/2,
+         enc_type_mismatch/2]).
 
 %%---------------------------------
 %% Construct bitstrings.
@@ -162,6 +163,13 @@ f36(X) ->
 f37(X) ->
   case X of
     <<_:42>> -> error(not_ok);
+    _ -> ok
+  end.
+
+-spec enc_type_mismatch(any(), integer()) -> ok.
+enc_type_mismatch(V, Sz) ->
+  case <<V:Sz>> of
+    <<42>> -> error(bug);
     _ -> ok
   end.
 

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -35,7 +35,9 @@
             "arity": 3,
             "nondeterministic": true,
             "solutions": [
-                "(5 << ($2 + $3)) + (($1 % (1 << $2)) << $3) + (2 % (1 << $3)) == 186"
+                "$3 < 0",
+                "$2 < 0",
+                "((5 << ($2 + $3)) + (($1 % (1 << $2)) << $3) + (2 % (1 << $3)) == 186) and $3 >= 0 and $2 >= 0"
             ],
             "skip": false
         },
@@ -48,7 +50,22 @@
             "arity": 3,
             "nondeterministic": true,
             "solutions": [
-                "(5 << ($2 + $3)) + (($1 % (1 << $2)) << $3) + (2 % (1 << $3)) == 186"
+                "((5 << ($2 + $3)) + (($1 % (1 << $2)) << $3) + (2 % (1 << $3)) == 186) and $3 >= 0 and $2 >= 0"
+            ],
+            "skip": false
+        },
+        {
+            "module": "bitstr",
+            "function": "enc_type_mismatch",
+            "args": "[foo, 0]",
+            "depth": "15",
+            "errors": true,
+            "arity": 2,
+            "nondeterministic": true,
+            "solutions": [
+                "not isinstance($1, int)",
+                "$2 < 0",
+                "(($1 % (1 << $2))  == 42) and isinstance($1, int) and $2 >= 0"
             ],
             "skip": false
         },
@@ -68,7 +85,7 @@
             "module": "bitstr",
             "function": "f22",
             "args": "[<<>>, 42]",
-            "depth": "8",
+            "depth": "9",
             "errors": true,
             "arity": 2,
             "nondeterministic": true,
@@ -81,7 +98,7 @@
             "module": "bitstr",
             "function": "f23",
             "args": "[0, 0]",
-            "depth": "7",
+            "depth": "8",
             "errors": true,
             "arity": 2,
             "nondeterministic": true,
@@ -94,7 +111,7 @@
             "module": "bitstr",
             "function": "f24",
             "args": "[<<>>, 0]",
-            "depth": "8",
+            "depth": "9",
             "errors": true,
             "arity": 2,
             "solutions": [
@@ -118,7 +135,7 @@
             "module": "bitstr",
             "function": "f25",
             "args": "[<<>>, 0]",
-            "depth": "8",
+            "depth": "9",
             "errors": true,
             "arity": 2,
             "nondeterministic": true,
@@ -131,7 +148,7 @@
             "module": "bitstr",
             "function": "f26",
             "args": "[<<>>, 0]",
-            "depth": "10",
+            "depth": "11",
             "errors": true,
             "arity": 2,
             "nondeterministic": true,
@@ -167,7 +184,7 @@
             "module": "bitstr",
             "function": "f32",
             "args": "[<<>>, 0, 3]",
-            "depth": "11",
+            "depth": "12",
             "errors": true,
             "arity": 3,
             "nondeterministic": true,
@@ -180,7 +197,7 @@
             "module": "bitstr",
             "function": "f33",
             "args": "[<<>>, 0, 0, <<>>]",
-            "depth": "21",
+            "depth": "22",
             "errors": true,
             "arity": 4,
             "nondeterministic": true,


### PR DESCRIPTION
Branching points on size and type of segments

Try to generate inputs that will cause bitstring construction or
matching to fail due to
- Negative sizes in segment size.
- Incompatible arguments with respect to the type expected by the
  segment.